### PR TITLE
 Added type information for vuelidate. Fixed tests and a bug.

### DIFF
--- a/vue/sbc-common-components/package.json
+++ b/vue/sbc-common-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sbc-common-components",
-  "version": "0.0.23",
+  "version": "0.0.24",
   "private": false,
   "description": "Common Vue Components to be used across SBC projects",
   "license": "Apache-2.0",

--- a/vue/sbc-common-components/src/components/BaseAddress.vue
+++ b/vue/sbc-common-components/src/components/BaseAddress.vue
@@ -190,7 +190,7 @@ export default class BaseAddress extends Vue {
   /**
    * Lifecycle callback to convert the address JSON into an object, so that it can be used by the template.
    */
-  private created () : void {
+  private created (): void {
     // Let the parent know right away about the validity of the address.
     this.emitValid()
   }
@@ -199,7 +199,7 @@ export default class BaseAddress extends Vue {
    * Lifecycle callback to store the mounted state of the component. We don't want the address watcher firing events
    * while the component is being set up.
    */
-  private mounted () : void {
+  private mounted (): void {
     this.isMounted = true
   }
 
@@ -209,7 +209,7 @@ export default class BaseAddress extends Vue {
    * @returns the {@link addressLocal} object.
    */
   @Emit('update:address')
-  private emitAddress () : object {
+  private emitAddress (): object {
     return this.addressLocal
   }
 
@@ -219,7 +219,7 @@ export default class BaseAddress extends Vue {
    * @returns a boolean that is true if the address if valid, false otherwise.
    */
   @Emit('valid')
-  private emitValid () : boolean {
+  private emitValid (): boolean {
     return !this.$v.$invalid
   }
 
@@ -229,8 +229,8 @@ export default class BaseAddress extends Vue {
    * @returns a boolean that is true if the address has been modified, false otherwise.
    */
   @Emit('modified')
-  private emitModified () : boolean {
-    return JSON.stringify(this.addressOriginal) !== JSON.stringify(this.addressLocal)
+  private emitModified (): boolean {
+    return BaseAddress.stringify(this.addressOriginal) !== BaseAddress.stringify(this.addressLocal)
   }
 
   /**
@@ -238,7 +238,7 @@ export default class BaseAddress extends Vue {
    * backs the display will be updated.
    */
   @Watch('address', { deep: true })
-  private onAddressChanged () : void {
+  private onAddressChanged (): void {
     this.addressLocal = { ...this.address }
   }
 
@@ -247,12 +247,23 @@ export default class BaseAddress extends Vue {
    * parent object with the new address and whether or not the address is valid.
    */
   @Watch('addressLocal', { deep: true, immediate: true })
-  private onAddressLocalChanged () : void {
+  private onAddressLocalChanged (): void {
     if (this.isMounted) {
       this.emitAddress()
       this.emitValid()
       this.emitModified()
     }
+  }
+
+  /**
+   * A convenience method for JSON.stringify that strips values that have empty strings.
+   *
+   * @param object the object to stringify.
+   *
+   * @returns a string that is the JSON representation of the object.
+   */
+  private static stringify (object: object): string {
+    return JSON.stringify(object, (name: string, val: any) : any => { return val !== '' ? val : undefined })
   }
 }
 

--- a/vue/sbc-common-components/src/vuelidate.d.ts
+++ b/vue/sbc-common-components/src/vuelidate.d.ts
@@ -1,0 +1,35 @@
+//
+// Copyright © 2019 Province of British Columbia
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+//
+
+// TypeScript types declarations for vuelidate JavaScript package.
+declare module 'vuelidate' {
+  import vue from 'vue'
+
+  export const validationMixin
+
+  module 'vue/types/options' {
+    interface ComponentOptions<V extends vue> {
+      validations?: { [x: string]: any }
+    }
+  }
+
+  module 'vue/types/vue' {
+    interface Vue {
+      $v?: { [x: string]: any }
+    }
+  }
+}
+
+declare module 'vuelidate/lib/validators' {
+  function required(value: any): boolean
+}


### PR DESCRIPTION
No breaking changes.

Fixed IDE and build complaints about the untyped vuelidate library. Fixed a bug where if the user entered something in a blank (undefined) field and then removed it, it was an empty string and showing up as a modification. Fixed up tests to be more Jest-y and remove async nextTick waits. Bumped version to 0.0.24.