### PR TITLE
Put in workarounds to allow foreign addresses (#962)

### DIFF
--- a/vue/sbc-common-components/src/components/BaseAddress.vue
+++ b/vue/sbc-common-components/src/components/BaseAddress.vue
@@ -80,6 +80,7 @@
                     name="address-region"
                     v-model="addressLocal.addressRegion"
                     :items="regions"
+                    :rules="regionRules"
           ></v-select>
           <v-text-field box
                         class="item"
@@ -87,7 +88,7 @@
                         name="postal-code"
                         required
                         v-model="addressLocal.postalCode"
-                        :rules="regionRules"
+                        :rules="postalCodeRules"
           ></v-text-field>
         </div>
         <div class="form__row">
@@ -175,16 +176,16 @@ export default class BaseAddress extends Vue {
   /**
    * The provinces for the address region drop-down list.
    */
-  private regions: string[] = [
-    'BC', 'AB', 'MB', 'NB', 'NL', 'NS', 'NT', 'NU', 'ON', 'PE', 'QC', 'SK', 'YT'
+  private readonly regions: string[] = [
+    'BC', 'AB', 'MB', 'NB', 'NL', 'NS', 'NT', 'NU', 'ON', 'PE', 'QC', 'SK', 'YT', '--'
   ]
 
   // TODO: Convert from Vuetify validation to Vuelidate using JSON Schema - temporarily using Vuetify for display.
-  private streetRules = [ v => !!v || 'A street address is required' ]
-  private cityRules = [ v => !!v || 'A city is required' ]
-  private regionRules = [ v => !!v || 'A province/state is required' ]
-  private postalCodeRules = [ v => !!v || 'A postal code is required' ]
-  private countryRules = [ v => !!v || 'A country is required' ]
+  private readonly streetRules = [ v => !!v || 'A street address is required' ]
+  private readonly cityRules = [ v => !!v || 'A city is required' ]
+  private readonly regionRules = [ v => !!v || 'A province is required' ]
+  private readonly postalCodeRules = [ v => !!v || 'A postal code is required' ]
+  private readonly countryRules = [ v => !!v || 'A country is required' ]
 
   /**
    * Lifecycle callback to convert the address JSON into an object, so that it can be used by the template.
@@ -350,9 +351,16 @@ export default class BaseAddress extends Vue {
     this.addressLocal['streetAddress'] = address['Line1']
     this.addressLocal['streetAddressAdditional'] = address['Line2']
     this.addressLocal['addressCity'] = address['City']
-    this.addressLocal['addressRegion'] = address['ProvinceCode']
-    this.addressLocal['postalCode'] = address['PostalCode']
     this.addressLocal['addressCountry'] = address['CountryIso2']
+
+    if (address['CountryIso2'] === 'CA') {
+      this.addressLocal['addressRegion'] = address['ProvinceCode']
+      this.addressLocal['postalCode'] = address['PostalCode']
+    } else {
+      // Not proud of this, but it'll do until we get implement JSON Schema validation.
+      this.addressLocal['addressRegion'] = '--'
+      this.addressLocal['postalCode'] = address['PostalCode'] ? address['PostalCode'] : 'N/A'
+    }
   }
 }
 

--- a/vue/sbc-common-components/src/components/BaseAddress.vue
+++ b/vue/sbc-common-components/src/components/BaseAddress.vue
@@ -357,7 +357,7 @@ export default class BaseAddress extends Vue {
       this.addressLocal['addressRegion'] = address['ProvinceCode']
       this.addressLocal['postalCode'] = address['PostalCode']
     } else {
-      // Not proud of this, but it'll do until we get implement JSON Schema validation.
+      // Not proud of this, but it'll do until we implement JSON Schema validation.
       this.addressLocal['addressRegion'] = '--'
       this.addressLocal['postalCode'] = address['PostalCode'] ? address['PostalCode'] : 'N/A'
     }


### PR DESCRIPTION
Added the following workarounds to allow foreign address entry:
- Region: added region "--". If a foreign address is returned by AddressComplete, the region will be set to "--". Potential problems: User can put "--" as the region for Canadian addresses. Also, user cannot enter a state if a US address (never could, but continues to be a problem).
 - Postal Code: If AddressComplete returns a foreign address, if the postal code is empty it will be set to "N/A".

Also fixed the following:
 - The region validation wasn't being used for showing error messages.
 - The region error message was being used for the postal code.
 - The region error message said a province/state is required but we don't allow states.
 - Stumbled over the readonly keyword in TypeScript and sprinkled the code with it.