### PR TITLE
Setup vuetify a la carte

### DIFF
--- a/vue/sbc-common-components/package.json
+++ b/vue/sbc-common-components/package.json
@@ -26,8 +26,7 @@
     "vue": "^2.6.10",
     "vue-class-component": "^7.0.2",
     "vue-property-decorator": "^8.1.0",
-    "vuelidate": "^0.7.4",
-    "vuetify": "^1.5.6"
+    "vuelidate": "^0.7.4"
   },
   "devDependencies": {
     "@types/jest": "^23.1.4",
@@ -49,9 +48,10 @@
     "stylus-loader": "^3.0.2",
     "ts-jest": "^23.0.0",
     "typescript": "^3.4.3",
+    "vue-router": "^3.0.3",
     "vue-template-compiler": "^2.5.21",
     "vuepress": "^0.14.11",
-    "vue-router": "^3.0.3",
+    "vuetify": "^1.5.6",
     "vuex": "^3.0.1"
   },
   "files": [

--- a/vue/sbc-common-components/src/plugins/vuetify.ts
+++ b/vue/sbc-common-components/src/plugins/vuetify.ts
@@ -1,8 +1,13 @@
 import 'material-icons/iconfont/material-icons.css' // Ensure you are using css-loader
-import Vue from 'vue'
-import Vuetify from 'vuetify'
 import 'vuetify/dist/vuetify.min.css'
+import Vue from 'vue'
+import Vuetify, {
+  VAlert
+} from 'vuetify/lib'
 
 Vue.use(Vuetify, {
-  iconfont: 'md'
+  iconfont: 'md',
+  components: {
+    VAlert
+  }
 })

--- a/vue/sbc-common-components/src/plugins/vuetify.ts
+++ b/vue/sbc-common-components/src/plugins/vuetify.ts
@@ -2,12 +2,16 @@ import 'material-icons/iconfont/material-icons.css' // Ensure you are using css-
 import 'vuetify/dist/vuetify.min.css'
 import Vue from 'vue'
 import Vuetify, {
-  VAlert
+  VAlert,
+  VContainer,
+  VIcon
 } from 'vuetify/lib'
 
 Vue.use(Vuetify, {
   iconfont: 'md',
   components: {
-    VAlert
+    VAlert,
+    VContainer,
+    VIcon
   }
 })


### PR DESCRIPTION
Issue #: https://github.com/bcgov/entity/issues/1011

Description of changes:
- Configured vuetify to only import components that are currently being used in sbc-common-components. As additional vuetify components are used, they will need to be manually added to the list in vuetify.ts
- This change was made in order to decrease the bundle size of sbc-common-components. Before setting up vuetify a la carte, sbc-common-lib.common.js was **1406.97 KiB**. With this change, sbc-common-lib.common.js will be **388.17 KiB**.