### PR TITLE
Update deployvuepress.sh to point to bcgov repo

### DIFF
--- a/vue/sbc-common-components/deployvuepress.sh
+++ b/vue/sbc-common-components/deployvuepress.sh
@@ -20,6 +20,6 @@ git commit -m 'deploy'
 # git push -f git@github.com:<USERNAME>/<USERNAME>.github.io.git master
 
 # if you are deploying to https://<USERNAME>.github.io/<REPO>
-git push -f git@github.com:saravankumarpa/sbc-common-components.git master:gh-pages
+git push -f git@github.com:bcgov/sbc-common-components.git master:gh-pages
 
 cd -


### PR DESCRIPTION
Description of changes:
- Updated the script that deploys our vuepress documentation to point to bcgov/sbc-common-components rather than saravan's repo