### PR TITLE
Changing the url to /auth/signout to redirect the user to auth applic…

### DIFF
--- a/vue/sbc-common-components/package.json
+++ b/vue/sbc-common-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sbc-common-components",
-  "version": "1.0.11",
+  "version": "2.0.0",
   "private": false,
   "description": "Common Vue Components to be used across SBC projects",
   "license": "Apache-2.0",

--- a/vue/sbc-common-components/src/components/SbcHeader.vue
+++ b/vue/sbc-common-components/src/components/SbcHeader.vue
@@ -31,19 +31,7 @@ export default Vue.extend({
   },
   methods: {
     logout () {
-      AuthService.logout(sessionStorage.getItem('KEYCLOAK_REFRESH_TOKEN'), this.authURL).then(response => {
-        if (response.status === 204) {
-          sessionStorage.removeItem('KEYCLOAK_REFRESH_TOKEN')
-          sessionStorage.removeItem('KEYCLOAK_TOKEN')
-          sessionStorage.removeItem('REGISTRIES_TRACE_ID')
-          sessionStorage.removeItem('AUTH_WEB')
-          window.location.assign('/auth')
-        } else {
-          console.log('Logout failed. ' + response)
-        }
-      }).catch((error: any) => {
-        console.log('fetchError' + error)
-      })
+      window.location.assign('/auth/signout')
     }
   }
 })


### PR DESCRIPTION
Issue:
https://github.com/bcgov/entity/issues/965

Description:
The current passcode signout invokes the auth-api to invalidate the token. Changing this to redirect to /auth/signout to take care of login with identity providers (bcsc and idir)
