### PR TITLE
implemented country drop-down and related UX/UI changes

### DIFF
--- a/vue/sbc-common-components/package-lock.json
+++ b/vue/sbc-common-components/package-lock.json
@@ -5446,6 +5446,11 @@
         "parse-json": "^4.0.0"
       }
     },
+    "country-list": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/country-list/-/country-list-2.2.0.tgz",
+      "integrity": "sha512-AS21pllCp72LmUztqXPVKXK3TRyap1XlohGLqN04cXH2rFB9vo7SnH5sMnqltZPnu9ie/x1se3UuCZJbGXErfw=="
+    },
     "create-ecdh": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
@@ -14742,6 +14747,11 @@
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
       "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
       "dev": true
+    },
+    "provinces": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/provinces/-/provinces-1.11.0.tgz",
+      "integrity": "sha1-Rni9Y+iBHwoZTrwcV+7hxV585sI="
     },
     "proxy-addr": {
       "version": "2.0.5",

--- a/vue/sbc-common-components/package.json
+++ b/vue/sbc-common-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sbc-common-components",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "private": false,
   "description": "Common Vue Components to be used across SBC projects",
   "license": "Apache-2.0",
@@ -22,8 +22,10 @@
     "@types/vuelidate": "^0.7.4",
     "axios": "^0.18.0",
     "core-js": "^2.6.5",
+    "country-list": "^2.2.0",
     "lodash": "^4.17.11",
     "material-icons": "^0.3.1",
+    "provinces": "^1.11.0",
     "vue": "^2.6.10",
     "vue-class-component": "^7.1.0",
     "vue-plugin-helper-decorator": "^0.0.11",

--- a/vue/sbc-common-components/src/mixins/countries-provinces-mixin.ts
+++ b/vue/sbc-common-components/src/mixins/countries-provinces-mixin.ts
@@ -1,0 +1,60 @@
+import { Component, Vue } from 'vue-property-decorator'
+
+// import these and sort them only once globally
+window['countries'] = window['countries'] || require('country-list/data.json')
+  .sort((a, b) => (a.name < b.name) ? -1 : (a.name > b.name) ? 1 : 0)
+
+window['provinces'] = window['provinces'] || require('provinces/provinces.json')
+  .sort((a, b) => (a.name < b.name) ? -1 : (a.name > b.name) ? 1 : 0)
+
+// global caching to improve performance when called multiple times
+window['countryNameCache'] = {}
+window['countryRegionsCache'] = {}
+
+/**
+ * Mixin that allows VM access to useful country/province data and functions.
+ * @link https://www.npmjs.com/package/country-list
+ * @lint https://www.npmjs.com/package/provinces
+ */
+@Component
+export default class CountriesProvincesMixin extends Vue {
+  /**
+   * Helper function to return a list of countries.
+   * @returns An array of country objects, sorted alphabetically.
+   */
+  getCountries (): Array<object> {
+    return window['countries']
+  }
+
+  /**
+   * Helper function to return a country's name.
+   * @param code The short code of the country.
+   * @returns The long name of the country.
+   */
+  getCountryName (code: string): string {
+    if (!code) return null
+    if (window['countryNameCache'][code]) return window['countryNameCache'][code]
+    const country = window['countries'].find(c => c.code === code)
+    const result = country ? country.name : null
+    window['countryNameCache'][code] = result
+    return result
+  }
+
+  /**
+   * Helper function to return a country's list of provinces.
+   * @param code The short code of the country.
+   * @returns An array of province objects, sorted alphabetically.
+   */
+  getCountryRegions (code: string): Array<object> {
+    if (!code) return null
+    if (window['countryRegionsCache'][code]) return window['countryRegionsCache'][code]
+    const result = window['provinces']
+      .filter(p => p.country === code)
+      .map(p => ({
+        name: p.english || p.name,
+        short: (p.short && p.short.length <= 2) ? p.short : '--'
+      }))
+    window['countryRegionsCache'][code] = result
+    return result
+  }
+}

--- a/vue/sbc-common-components/tests/unit/BaseAddress.spec.ts
+++ b/vue/sbc-common-components/tests/unit/BaseAddress.spec.ts
@@ -32,9 +32,9 @@ const basicAddress = {
   streetAddress: '1234 Main St',
   streetAddressAdditional: 'PO BOX STN PROV GOV',
   addressCity: 'Victoria',
-  addressRegion: 'BC',
+  addressRegion: 'BC', // NB: region code
   postalCode: 'V8W 3J3',
-  addressCountry: 'Canada',
+  addressCountry: 'CA', // NB: country code
   deliveryInstructions: 'c/o The Management'
 }
 
@@ -166,11 +166,11 @@ describe('BaseAddress - base tests', () => {
   })
 
   it('displays a Canadian address', () => {
-    const wrapper: Wrapper<BaseAddress> = createComponent(basicAddress, false)
+    const wrapper: Wrapper<BaseAddress> = createComponent(undefined, false)
 
     // We should be in display mode.
-    expect(wrapper.find('.address-block').isVisible()).toBe(true)
-    expect(wrapper.find('form[name="address-form"').isVisible()).toBe(false)
+    expect(wrapper.find('.address-block').exists()).toBe(true)
+    expect(wrapper.find('[name="address-form"]').exists()).toBe(false)
 
     // The last "valid" event should indicate that the address is valid.
     expect(wrapper.emitted().valid).toBeDefined()
@@ -180,18 +180,18 @@ describe('BaseAddress - base tests', () => {
     expect(wrapper.find('.address-block').text()).toContain(basicAddress.streetAddress)
     expect(wrapper.find('.address-block').text()).toContain(basicAddress.streetAddressAdditional)
     expect(wrapper.find('.address-block').text()).toContain(basicAddress.addressCity)
-    expect(wrapper.find('.address-block').text()).toContain(basicAddress.addressRegion)
+    expect(wrapper.find('.address-block').text()).toContain(basicAddress.addressRegion) // NB: region code
     expect(wrapper.find('.address-block').text()).toContain(basicAddress.postalCode)
-    expect(wrapper.find('.address-block').text()).toContain(basicAddress.addressCountry)
+    expect(wrapper.find('.address-block').text()).toContain('Canada') // NB: long name
     expect(wrapper.find('.address-block').text()).toContain(basicAddress.deliveryInstructions)
   })
 
   it('edits a Canadian address', () => {
-    const wrapper: Wrapper<BaseAddress> = createComponent()
+    const wrapper: Wrapper<BaseAddress> = createComponent(undefined, true)
 
     // We should be in edit mode.
-    expect(wrapper.find('.address-block').isVisible()).toBe(false)
-    expect(wrapper.find('[name="address-form"').isVisible()).toBe(true)
+    expect(wrapper.find('.address-block').exists()).toBe(false)
+    expect(wrapper.find('[name="address-form"]').exists()).toBe(true)
 
     // The last "valid" event should indicate that the address is valid.
     expect(wrapper.emitted().valid).toBeDefined()
@@ -204,9 +204,11 @@ describe('BaseAddress - base tests', () => {
     expect(wrapper.find('[name="address-city"]').element['value']).toEqual(basicAddress.addressCity)
     // NB: for v-select, look at the div before the input
     expect(wrapper.find('[name="address-region"]').element['previousElementSibling'].textContent)
-      .toEqual(basicAddress.addressRegion)
+      .toEqual('British Columbia') // NB: long name
     expect(wrapper.find('[name="postal-code"]').element['value']).toEqual(basicAddress.postalCode)
-    expect(wrapper.find('[name="address-country"]').element['value']).toEqual(basicAddress.addressCountry)
+    // NB: for v-select, look at the div before the input
+    expect(wrapper.find('[name="address-country"]').element['previousElementSibling'].textContent)
+      .toEqual('Canada') // NB: long name
     expect(wrapper.find('[name="delivery-instructions"]').element['value'])
       .toEqual(basicAddress.deliveryInstructions)
   })
@@ -442,6 +444,7 @@ describe('BaseAddress - validation rules', () => {
     const wrapper: Wrapper<BaseAddress> = mount(BaseAddress, {
       propsData: {
         address: { addressCountry: 'Canada' },
+        editing: true,
         schema: {
           addressCountry: { minLength: minLength(7) }
         }
@@ -464,6 +467,7 @@ describe('BaseAddress - validation rules', () => {
     const wrapper: Wrapper<BaseAddress> = mount(BaseAddress, {
       propsData: {
         address: { addressCountry: 'Canada' },
+        editing: true,
         schema: {
           addressCountry: { maxLength: maxLength(5) }
         }
@@ -486,6 +490,7 @@ describe('BaseAddress - validation rules', () => {
     const wrapper: Wrapper<BaseAddress> = mount(BaseAddress, {
       propsData: {
         address: { addressCountry: 'USA' },
+        editing: true,
         schema: {
           addressCountry: { isCanada: (val) => (val === 'Canada') }
         }


### PR DESCRIPTION
*Issue #:* /bcgov/entity#1192

*Description of changes:*
- updated my version to 1.0.14
- added packages to get countries and provinces
- changed some v-show to v-if to reduce data loaded multiple times
- now manage addressCountry as 2-char code (in line with schema)
- updated streetAddressAdditional to support more than 1 line
- added missing rules!
- implemented addressRegion as v-select or v-text-field as applicable
- changed country to v-select
- implemented dynamic labels per UX/UI wireframe
- removed confusing/nonfunctional PCA country selector
- changed streetAddressAdditional to include address lines 2, 3, 4 and 5
- allowed null region
- added Province Name to streetAddressAdditional as applicable (for future PCA int'l address lookups)
- implemented mixin to get countries and provinces
- updated and fixed unit tests as applicable