### PR TITLE
quick fix to address styling

### DIFF
--- a/vue/sbc-common-components/package.json
+++ b/vue/sbc-common-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sbc-common-components",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "private": false,
   "description": "Common Vue Components to be used across SBC projects",
   "license": "Apache-2.0",

--- a/vue/sbc-common-components/src/components/BaseAddress.vue
+++ b/vue/sbc-common-components/src/components/BaseAddress.vue
@@ -88,7 +88,7 @@
                     v-model="addressLocal.addressRegion"
                     :items="getCountryRegions(countryCode)"
                     :rules="rules.addressRegion"
-                    :disabled="isSchemaBC()"
+                    :readonly="isSchemaBC()"
           />
           <v-text-field v-else
                         filled
@@ -116,7 +116,7 @@
                     v-model="addressLocal.addressCountry"
                     :items="getCountries()"
                     :rules="rules.addressCountry"
-                    :disabled="isSchemaCanada()"
+                    :readonly="isSchemaCanada()"
           />
         </div>
         <div class="form__row">


### PR DESCRIPTION
- changed v-select disabled to readonly so errors are displayed in red (due to Vuetify 2 upgrade)
- updated version