### PR TITLE
updated version to 2.0.16

### DIFF
--- a/vue/sbc-common-components/package.json
+++ b/vue/sbc-common-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sbc-common-components",
-  "version": "2.0.15",
+  "version": "2.0.16",
   "private": false,
   "description": "Common Vue Components to be used across SBC projects",
   "license": "Apache-2.0",


### PR DESCRIPTION
This is to work around an actions snafu, where a push to a feature branch caused a npm publish, and then when the branch was merged into master, re-publish failed because the package version number was the same.