### PR TITLE
make Province and Country appear disabled

### DIFF
--- a/vue/sbc-common-components/package.json
+++ b/vue/sbc-common-components/package.json
@@ -19,7 +19,6 @@
     "docs:build": "vuepress build docs"
   },
   "dependencies": {
-    "@types/vuelidate": "^0.7.4",
     "axios": "^0.18.0",
     "core-js": "^3.1.4",
     "country-list": "^2.2.0",
@@ -29,9 +28,6 @@
     "provinces": "^1.11.0",
     "regenerator-runtime": "^0.13.3",
     "vue": "^2.6.10",
-    "vue-class-component": "^7.1.0",
-    "vue-plugin-helper-decorator": "^0.0.11",
-    "vue-property-decorator": "^8.2.2",
     "vue-router": "^3.0.3",
     "vue2-filters": "^0.7.1",
     "vuelidate": "^0.7.4",
@@ -40,6 +36,7 @@
   },
   "devDependencies": {
     "@types/jest": "^24.0.18",
+    "@types/vuelidate": "^0.7.4",
     "@typescript-eslint/eslint-plugin": "^2.3.1",
     "@typescript-eslint/parser": "^2.3.1",
     "@vue/cli-plugin-babel": "4.0.0-rc.0",
@@ -60,6 +57,9 @@
     "sass-loader": "^7.2.0",
     "ts-jest": "^24.0.2",
     "typescript": "<3.6.0",
+    "vue-class-component": "^7.1.0",
+    "vue-plugin-helper-decorator": "^0.0.11",
+    "vue-property-decorator": "^8.2.2",
     "vue-template-compiler": "^2.6.10",
     "vuepress": "^0.14.11"
   },

--- a/vue/sbc-common-components/src/components/BaseAddress.vue
+++ b/vue/sbc-common-components/src/components/BaseAddress.vue
@@ -518,7 +518,7 @@ export default class BaseAddress extends Mixins(ValidationMixin, CountriesProvin
 </script>
 
 <style lang="scss" scoped>
-@import "../../src/assets/scss/theme.scss";
+@import "../assets/scss/theme.scss";
 
 .meta-container {
   display: flex;
@@ -559,5 +559,28 @@ export default class BaseAddress extends Mixins(ValidationMixin, CountriesProvin
 
 .pre-wrap {
   white-space: pre-wrap;
+}
+
+// make 'readonly' inputs looks disabled
+// (can't use 'disabled' because we want normal error styling)
+.v-select.v-input--is-readonly,
+.v-text-field.v-input--is-readonly {
+  pointer-events: none;
+
+  ::v-deep .v-label {
+    // set label colour to same as disabled
+    color: rgba(0,0,0,.38);
+  }
+
+  ::v-deep .v-select__selection {
+    // set selection colour to same as disabled
+    color: rgba(0,0,0,.38);
+  }
+
+  ::v-deep .v-icon {
+    // set error icon colour to same as disabled
+    color: rgba(0,0,0,.38) !important;
+    opacity: 0.6;
+  }
 }
 </style>


### PR DESCRIPTION
*Issue #:* /bcgov/entity/1673

*Description of changes:*
- made readonly inputs look disabled (while still displaying normal error styling)
- updated prod vs dev dependencies

**Note that this is not a high-priority fix so I did not update the package version number. I am aware that other things needs to be fixed (ie, icons) in this branch, so when those are fixed then we can update the version.**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).