### PR TITLE
A TS fix for PPR

### DIFF
--- a/vue/sbc-common-components/package.json
+++ b/vue/sbc-common-components/package.json
@@ -47,7 +47,7 @@
     "@vue/cli-service": "4.0.0-rc.0",
     "@vue/eslint-config-standard": "^4.0.0",
     "@vue/eslint-config-typescript": "^4.0.0",
-    "@vue/test-utils": "1.0.0-beta.28",
+    "@vue/test-utils": "1.0.0-beta.29",
     "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "^10.0.1",
     "eslint": "^5.16.0",

--- a/vue/sbc-common-components/src/components/SbcHeader.vue
+++ b/vue/sbc-common-components/src/components/SbcHeader.vue
@@ -63,7 +63,7 @@ export default class SbcHeader extends Vue {
 
   get showLogin () : boolean {
     let featureHide: any
-    let config: string = sessionStorage.getItem('AUTH_API_CONFIG') || '{}'
+    let config = sessionStorage.getItem('AUTH_API_CONFIG') || '{}'
     const authApiConfig = JSON.parse(config)
 
     if (authApiConfig) {

--- a/vue/sbc-common-components/src/components/SbcHeader.vue
+++ b/vue/sbc-common-components/src/components/SbcHeader.vue
@@ -63,7 +63,8 @@ export default class SbcHeader extends Vue {
 
   get showLogin () : boolean {
     let featureHide: any
-    const authApiConfig = JSON.parse(sessionStorage.getItem('AUTH_API_CONFIG'))
+    let config: string = sessionStorage.getItem('AUTH_API_CONFIG') || '{}'
+    const authApiConfig = JSON.parse(config)
 
     if (authApiConfig) {
       featureHide = authApiConfig['VUE_APP_FEATURE_HIDE']


### PR DESCRIPTION
PPR uses strict typescript checking. This fix is required for PPR to use these common components.
Plus, fix large number of unit test failures
Updating the test package resolves numerous unit test errors that have the form
    console.error node_modules/vue/dist/vue.runtime.common.dev.js:1884
      TypeError: Cannot read property '_transitionClasses' of undefined