### PR TITLE
prevent extra whitespace in addresses

### DIFF
--- a/vue/sbc-common-components/package.json
+++ b/vue/sbc-common-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sbc-common-components",
-  "version": "2.0.29",
+  "version": "2.0.30",
   "private": false,
   "description": "Common Vue Components to be used across SBC projects",
   "license": "Apache-2.0",
@@ -19,12 +19,10 @@
     "docs:build": "vuepress build docs"
   },
   "dependencies": {
+    "@mdi/font": "^4.5.95",
     "axios": "^0.18.0",
     "core-js": "^3.1.4",
     "country-list": "^2.2.0",
-    "lodash.set": "^4.3.2",
-    "lodash.unset": "^4.5.2",
-    "@mdi/font": "^4.5.95",
     "provinces": "^1.11.0",
     "regenerator-runtime": "^0.13.3",
     "vue": "^2.6.10",

--- a/vue/sbc-common-components/src/mixins/validation-mixin.ts
+++ b/vue/sbc-common-components/src/mixins/validation-mixin.ts
@@ -11,7 +11,15 @@ export default class ValidationMixin extends Vue {
    * @returns A Vuetify rules object.
    */
   public createVuetifyRulesObject (model: string): { [attr: string]: Array<Function> } {
-    let obj = {}
+    let obj = {
+      streetAddress: [],
+      streetAddressAdditional: [],
+      addressCity: [],
+      addressRegion: [],
+      postalCode: [],
+      addressCountry: [],
+      deliveryInstructions: []
+    }
 
     // ensure Vuelidate state object is initialized
     if (this.$v && this.$v[model]) {


### PR DESCRIPTION
- added whitespace rules to all inputs
- replaced invalid 'name' attributes with classnames
- replaced lodash methods with ES6 ones
- removed original address that didn't work ('modified' event was never used anyway)
- fixed AC update that sometimes didn't validate
- initialized Vuetify rules object to prevent template errors
- general simplification and cleanup
- fixed unit tests
- removed lodash dependency
- updated version number