### PR TITLE
made Tokenservice stricter

### DIFF
--- a/vue/sbc-common-components/src/services/token.services.ts
+++ b/vue/sbc-common-components/src/services/token.services.ts
@@ -1,45 +1,46 @@
 import Keycloak, { KeycloakInitOptions, KeycloakInstance } from 'keycloak-js'
 
 class TokenServices {
-  private kc: KeycloakInstance
+  private kc: KeycloakInstance | undefined
   private static instance: TokenServices
-  private kcLoaded
   private counter = 0
   private REFRESH_ATTEMPT_INTERVAL = 10 // in seconds
-  private timerId
-  private kcOptions: KeycloakInitOptions = {
-    onLoad: 'login-required',
-    checkLoginIframe: false,
-    timeSkew: 0,
-    token: sessionStorage.getItem('KEYCLOAK_TOKEN'),
-    refreshToken: sessionStorage.getItem('KEYCLOAK_REFRESH_TOKEN'),
-    idToken: sessionStorage.getItem('KEYCLOAK_ID_TOKEN')
-  }
+  private timerId = 0
 
   initUsingKc (kcInstance: KeycloakInstance) {
-    console.info('[TokenServices] KC Instance registered using kc instance')
     this.kc = kcInstance
   }
 
   initUsingUrl (keyCloakConfigurl: string) {
-    console.info('[TokenServices] KC Instance registered using kc URL')
     var self = this
+
+    const kcOptions: KeycloakInitOptions = {
+      onLoad: 'login-required',
+      checkLoginIframe: false,
+      timeSkew: 0,
+      token: sessionStorage.getItem('KEYCLOAK_TOKEN') || undefined,
+      refreshToken: sessionStorage.getItem('KEYCLOAK_REFRESH_TOKEN') || undefined,
+      idToken: sessionStorage.getItem('KEYCLOAK_ID_TOKEN') || undefined
+    }
+
     return new Promise((resolve, reject) => {
       this.kc = Keycloak(keyCloakConfigurl)
-      this.kc.init(this.kcOptions
+      this.kc.init(kcOptions
       ).success(function (authenticated) {
         console.info('[TokenServices] is User Authenticated:Syncing' + authenticated)
         self.syncSessionStorage()
-        resolve(self.kc.token)
+        if (self.kc) {
+          resolve(self.kc.token)
+        } else {
+          reject(new Error('Could not Initialise KC'))
+        }
       }).error(function (err) {
-        console.info('[TokenServices] Fatal Error:Could not Initialise KC instance' + err)
-        reject(new Error('Could not Initialise KC'))
+        reject(new Error('Could not Initialise KC' + err))
       })
     })
   }
 
   scheduleRefreshTimer (refreshEarlyTime :number = 0) {
-    console.info('[TokenServices Starting the timer] ')
     let refreshEarlyTimeinMilliseconds = Math.max(this.REFRESH_ATTEMPT_INTERVAL, refreshEarlyTime) * 1000
     this.scheduleRefreshToken(refreshEarlyTimeinMilliseconds)
   }
@@ -47,18 +48,22 @@ class TokenServices {
   refreshToken () {
     console.log('[TokenServices] One time Token Refreshing ')
     return new Promise((resolve, reject) => {
-      this.kc.updateToken(-1)
-        .success(refreshed => {
-          if (refreshed) {
-            console.log('[TokenServices] One time Token Refreshed ')
-            this.syncSessionStorage()
-            resolve()
-          }
-        })
-        .error(() => {
-          // this.cleanupSession()
-          reject(new Error('Could not refresh Token'))
-        })
+      if (this.kc) {
+        this.kc.updateToken(-1)
+          .success(refreshed => {
+            if (refreshed) {
+              console.log('[TokenServices] One time Token Refreshed ')
+              this.syncSessionStorage()
+              resolve()
+            }
+          })
+          .error(() => {
+            // this.cleanupSession()
+            reject(new Error('Could not refresh Token'))
+          })
+      } else {
+        reject(new Error('Could not refresh Token:No Kc Instance'))
+      }
     })
   }
 
@@ -69,20 +74,26 @@ class TokenServices {
 
   private scheduleRefreshToken (refreshEarlyTimeinMilliseconds:number) {
     let self = this
-
+    let refreshTokenExpiresIn = -1
     // check if refresh token is still valid . Or else clear all timers and throw errors
-    let refreshTokenExpiresIn = self.kc.refreshTokenParsed['exp'] - Math.ceil(new Date().getTime() / 1000) + self.kc.timeSkew
+    if (self.kc !== undefined && self.kc.timeSkew !== undefined && self.kc.refreshTokenParsed !== undefined) {
+      refreshTokenExpiresIn = self.kc.refreshTokenParsed['exp']! - Math.ceil(new Date().getTime() / 1000) + self.kc.timeSkew
+    }
     if (refreshTokenExpiresIn < 0) {
       throw new Error('Refresh Token Expired..No more token refreshes')
     }
-
-    let expiresIn = self.kc.tokenParsed['exp'] - Math.ceil(new Date().getTime() / 1000) + self.kc.timeSkew
+    let expiresIn = -1
+    if (self.kc !== undefined && self.kc.tokenParsed !== undefined && self.kc.tokenParsed['exp'] !== undefined) {
+      expiresIn = self.kc.tokenParsed['exp'] - Math.ceil(new Date().getTime() / 1000) + self.kc!.timeSkew!
+    }
+    if (expiresIn < 0) {
+      throw new Error('Refresh Token Expired..No more token refreshes')
+    }
     let refreshInMilliSeconds = (expiresIn * 1000) - refreshEarlyTimeinMilliseconds // in milliseconds
-    console.info('[TokenServices] Token Expires in %s Seconds:', expiresIn)
     console.info('[TokenServices] Token Refreshal Scheduled in %s Seconds', (refreshInMilliSeconds / 1000))
     this.timerId = setTimeout(() => {
       console.log('[TokenServices] Refreshing Token Attempt: %s ', ++this.counter)
-      this.kc.updateToken(-1)
+      this.kc!.updateToken(-1)
         .success(refreshed => {
           if (refreshed) {
             console.log('successfully refreshed')
@@ -92,26 +103,36 @@ class TokenServices {
         })
         .error(() => {
           clearTimeout(this.timerId)
-          console.log('refresh failed')
         })
     }, refreshInMilliSeconds)
-    console.log('[TokenServices] Timer id:' + this.timerId)
   }
 
   private syncSessionStorage () {
-    sessionStorage.setItem('KEYCLOAK_TOKEN', this.kc.token)
-    sessionStorage.setItem('KEYCLOAK_REFRESH_TOKEN', this.kc.refreshToken)
-    sessionStorage.setItem('KEYCLOAK_ID_TOKEN', this.kc.idToken)
+    if (this.kc) {
+      if (this.kc.token != null) {
+        sessionStorage.setItem('KEYCLOAK_TOKEN', this.kc.token)
+      }
+      if (this.kc.refreshToken != null) {
+        sessionStorage.setItem('KEYCLOAK_REFRESH_TOKEN', this.kc.refreshToken)
+      }
+      if (this.kc.idToken != null) {
+        sessionStorage.setItem('KEYCLOAK_ID_TOKEN', this.kc.idToken)
+      }
+    }
   }
 
   decodeToken () {
     try {
       let token = sessionStorage.getItem('KEYCLOAK_TOKEN')
-      const base64Url = token.split('.')[1]
-      const base64 = decodeURIComponent(window.atob(base64Url).split('').map(function (c) {
-        return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2)
-      }).join(''))
-      return JSON.parse(base64)
+      if (token != null) {
+        const base64Url = token.split('.')[1]
+        const base64 = decodeURIComponent(window.atob(base64Url).split('').map(function (c) {
+          return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2)
+        }).join(''))
+        return JSON.parse(base64)
+      } else {
+        throw new Error('null JWT')
+      }
     } catch (error) {
       throw new Error('Error parsing JWT - ' + error)
     }

--- a/vue/sbc-common-components/src/services/token.services.ts
+++ b/vue/sbc-common-components/src/services/token.services.ts
@@ -83,8 +83,8 @@ class TokenServices {
       throw new Error('Refresh Token Expired..No more token refreshes')
     }
     let expiresIn = -1
-    if (self.kc !== undefined && self.kc.tokenParsed !== undefined && self.kc.tokenParsed['exp'] !== undefined) {
-      expiresIn = self.kc.tokenParsed['exp'] - Math.ceil(new Date().getTime() / 1000) + self.kc!.timeSkew!
+    if (self.kc !== undefined && self.kc.tokenParsed !== undefined && self.kc.tokenParsed['exp'] !== undefined && self.kc.timeSkew !== undefined) {
+      expiresIn = self.kc.tokenParsed['exp'] - Math.ceil(new Date().getTime() / 1000) + self.kc.timeSkew
     }
     if (expiresIn < 0) {
       throw new Error('Refresh Token Expired..No more token refreshes')


### PR DESCRIPTION
Changes for making tokenservice strict

List of changes
- used explicit null checks instead of non-null assertion operator in most of the places.Can use non-null assertion operator ;but sonar will throw errors if used

- removed some console.logs to reduce noise
