### PR TITLE
reverted TS optional chaining due to builder error

### DIFF
--- a/vue/sbc-common-components/src/services/fee.services.ts
+++ b/vue/sbc-common-components/src/services/fee.services.ts
@@ -31,9 +31,9 @@ export default {
         return args
           .map(response => response.data as PayData)
           .map(data => {
+            const filingDatum = filingData.find(fd => fd.filingTypeCode === data.filingTypeCode)
             // default the title if client hasn't passed this on
-            const filingDescription = filingData.find(fd => fd.filingTypeCode === data.filingTypeCode)?.filingDescription
-            const filingType = filingDescription || data.filingType
+            const filingType = (filingDatum && filingDatum.filingDescription) ? filingDatum.filingDescription : data.filingType
             // total fees is a sum of filingFees,serviceFees,processingFees , gst , pst
             const fee = data.filingFees + data.serviceFees + data.processingFees + data.tax.gst + data.tax.pst
             return { fee, filingType } as Fee


### PR DESCRIPTION
*Issue #:* /bcgov/entity#2357

*Description of changes:*
- reverted TS optional chaining due to builder error
- did not update version number -- this can go in with next fix 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).