### PR TITLE
Hide switch account for one account (#2665)

### DIFF
--- a/vue/sbc-common-components/package.json
+++ b/vue/sbc-common-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sbc-common-components",
-  "version": "2.0.45",
+  "version": "2.0.46",
   "private": false,
   "description": "Common Vue Components to be used across SBC projects.",
   "license": "Apache-2.0",

--- a/vue/sbc-common-components/src/components/SbcHeader.vue
+++ b/vue/sbc-common-components/src/components/SbcHeader.vue
@@ -103,7 +103,7 @@
 
           <v-divider></v-divider>
 
-          <v-list tile dense v-if="accountType !== 'IDIR' && switchableAccounts.length > 0">
+          <v-list tile dense v-if="accountType !== 'IDIR' && switchableAccounts.length > 1">
             <v-subheader>SWITCH ACCOUNT</v-subheader>
             <v-list-item @click="switchAccount(settings)" v-for="(settings, id) in switchableAccounts" :key="id">
               <v-list-item-icon left>


### PR DESCRIPTION
This PR is a simple change to hide the account switcher when there is only one account.