### PR TITLE
Add props for specifying redirect urls (#2563)

### DIFF
--- a/vue/sbc-common-components/package.json
+++ b/vue/sbc-common-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sbc-common-components",
-  "version": "2.0.46",
+  "version": "2.0.47",
   "private": false,
   "description": "Common Vue Components to be used across SBC projects.",
   "license": "Apache-2.0",

--- a/vue/sbc-common-components/src/components/SbcHeader.vue
+++ b/vue/sbc-common-components/src/components/SbcHeader.vue
@@ -120,9 +120,10 @@
 </template>
 
 <script lang="ts">
-import { Component, Mixins } from 'vue-property-decorator'
+import { Component, Mixins, Prop } from 'vue-property-decorator'
 import { initialize, LDClient } from 'launchdarkly-js-client-sdk'
 import ConfigHelper from '../util/config-helper'
+import CommonUtils from '../util/common-util'
 import { SessionStorageKeys } from '../util/constants'
 import { mapActions, mapState } from 'vuex'
 import { getModule } from 'vuex-module-decorators'
@@ -151,6 +152,9 @@ export default class SbcHeader extends NavigationMixin {
   private readonly pendingApprovalCount!: number;
   private readonly syncUserSettings!: (currentAccountId: string) => Promise<UserSettings[]>
   private readonly syncCurrentAccount!: (settings: UserSettings) => Promise<UserSettings>
+  @Prop({ default: '' }) redirectOnLoginSuccess!: string;
+  @Prop({ default: '' }) redirectOnLoginFail!: string;
+  @Prop({ default: '' }) redirectOnLogout!: string;
 
   get showAccountSwitching (): boolean {
     try {
@@ -225,11 +229,25 @@ export default class SbcHeader extends NavigationMixin {
   }
 
   logout () {
-    this.navigateTo(ConfigHelper.getAuthContextPath(), '/signout')
+    if (this.redirectOnLogout) {
+      this.navigateTo(
+        ConfigHelper.getAuthContextPath(),
+        `/signout/${CommonUtils.isUrl(this.redirectOnLogout) ? encodeURIComponent(this.redirectOnLogout) : this.redirectOnLogout}`
+      )
+    } else {
+      this.navigateTo(ConfigHelper.getAuthContextPath(), '/signout')
+    }
   }
 
   login () {
-    this.navigateTo(ConfigHelper.getAuthContextPath(), '/signin/bcsc')
+    if (this.redirectOnLoginSuccess) {
+      this.navigateTo(
+        ConfigHelper.getAuthContextPath(),
+        `/signin/bcsc/${CommonUtils.isUrl(this.redirectOnLoginSuccess) ? encodeURIComponent(this.redirectOnLoginSuccess) : this.redirectOnLoginSuccess}`
+      )
+    } else {
+      this.navigateTo(ConfigHelper.getAuthContextPath(), '/signin/bcsc')
+    }
   }
 
   private goToHome () {

--- a/vue/sbc-common-components/src/components/SbcHeader.vue
+++ b/vue/sbc-common-components/src/components/SbcHeader.vue
@@ -230,9 +230,10 @@ export default class SbcHeader extends NavigationMixin {
 
   logout () {
     if (this.redirectOnLogout) {
+      const url = encodeURIComponent(this.redirectOnLogout)
       this.navigateTo(
         ConfigHelper.getAuthContextPath(),
-        `/signout/${CommonUtils.isUrl(this.redirectOnLogout) ? encodeURIComponent(this.redirectOnLogout) : this.redirectOnLogout}`
+        `/signout/${url}`
       )
     } else {
       this.navigateTo(ConfigHelper.getAuthContextPath(), '/signout')
@@ -241,9 +242,11 @@ export default class SbcHeader extends NavigationMixin {
 
   login () {
     if (this.redirectOnLoginSuccess) {
+      let url = encodeURIComponent(this.redirectOnLoginSuccess)
+      url += this.redirectOnLoginFail ? `/${encodeURIComponent(this.redirectOnLoginFail)}` : ''
       this.navigateTo(
         ConfigHelper.getAuthContextPath(),
-        `/signin/bcsc/${CommonUtils.isUrl(this.redirectOnLoginSuccess) ? encodeURIComponent(this.redirectOnLoginSuccess) : this.redirectOnLoginSuccess}`
+        `/signin/bcsc/${url}`
       )
     } else {
       this.navigateTo(ConfigHelper.getAuthContextPath(), '/signin/bcsc')

--- a/vue/sbc-common-components/src/components/SbcHeader.vue
+++ b/vue/sbc-common-components/src/components/SbcHeader.vue
@@ -123,7 +123,6 @@
 import { Component, Mixins, Prop } from 'vue-property-decorator'
 import { initialize, LDClient } from 'launchdarkly-js-client-sdk'
 import ConfigHelper from '../util/config-helper'
-import CommonUtils from '../util/common-util'
 import { SessionStorageKeys } from '../util/constants'
 import { mapActions, mapState } from 'vuex'
 import { getModule } from 'vuex-module-decorators'

--- a/vue/sbc-common-components/src/util/common-util.ts
+++ b/vue/sbc-common-components/src/util/common-util.ts
@@ -19,10 +19,3 @@ export function getBoolean (value: boolean | string | number): boolean {
       return false
   }
 }
-
-const URL_MATCHER = new RegExp('^(?:\\w+:)?\\/\\/([^\\s\\.]+\\.\\S{2}|localhost[\\:?\\d]*)\\S*$')
-export default {
-  isUrl (value:string):boolean {
-    return URL_MATCHER.test(value)
-  }
-}

--- a/vue/sbc-common-components/src/util/common-util.ts
+++ b/vue/sbc-common-components/src/util/common-util.ts
@@ -19,3 +19,10 @@ export function getBoolean (value: boolean | string | number): boolean {
       return false
   }
 }
+
+const URL_MATCHER = new RegExp('^(?:\\w+:)?\\/\\/([^\\s\\.]+\\.\\S{2}|localhost[\\:?\\d]*)\\S*$')
+export default {
+  isUrl (value:string):boolean {
+    return URL_MATCHER.test(value)
+  }
+}


### PR DESCRIPTION
You can specify properties on the SbcHeader component for where you want to redirect to after login/logout/failure.

i.e.: 
`<sbc-header redirectOnLoginSuccess="https://your.url.com" redirectOnLogout="https://your.logout.landing.page.com"/>`

If you don't specify these properties, the default redirects are to the ones currently used in Auth (user profile and account setup, and manage businesses)