### PR TITLE
removed unnecessary event emit and staff doesnt need to access the account info

### DIFF
--- a/vue/sbc-common-components/package.json
+++ b/vue/sbc-common-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sbc-common-components",
-  "version": "2.1.8",
+  "version": "2.1.9",
   "private": false,
   "description": "Common Vue Components to be used across SBC projects",
   "license": "Apache-2.0",

--- a/vue/sbc-common-components/package.json
+++ b/vue/sbc-common-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sbc-common-components",
-  "version": "2.1.9",
+  "version": "2.1.10",
   "private": false,
   "description": "Common Vue Components to be used across SBC projects",
   "license": "Apache-2.0",

--- a/vue/sbc-common-components/src/components/SbcHeader.vue
+++ b/vue/sbc-common-components/src/components/SbcHeader.vue
@@ -196,7 +196,15 @@ export default class SbcHeader extends NavigationMixin {
     if (ConfigHelper.getFromSession(SessionStorageKeys.KeyCloakToken)) {
       const lastUsedAccount = this.getLastAccountId()
       await this.syncUserSettings(lastUsedAccount)
-      this.persistAndEmitAccountId()
+
+      /*
+     Emit event to downstream only when account id is changed.
+     ie ; on account switch or on when the app is loaded. Otherwise need not to propagate the changes
+     */
+      const isAccountChanged = lastUsedAccount !== this.currentAccount.id.toString()
+      if (isAccountChanged) {
+        this.persistAndEmitAccountId()
+      }
     }
   }
 

--- a/vue/sbc-common-components/src/components/SbcHeader.vue
+++ b/vue/sbc-common-components/src/components/SbcHeader.vue
@@ -193,7 +193,7 @@ export default class SbcHeader extends NavigationMixin {
       this.loadUserInfo()
     })
 
-    if (ConfigHelper.getFromSession(SessionStorageKeys.KeyCloakToken)) {
+    if (ConfigHelper.getFromSession(SessionStorageKeys.KeyCloakToken) && (this.accountType !== 'IDIR')) {
       const lastUsedAccount = this.getLastAccountId()
       await this.syncUserSettings(lastUsedAccount)
 


### PR DESCRIPTION
Might fix https://github.com/bcgov/entity/issues/2919

idea is to remove the unnecessary propagation of the events to the sub app. Now on all header refreshes , an event is emitted to the webapp which is not necessary.Only in account switch , the web app has to be notified.

Havent fully verified it.But hoping this will work.Or else will revert/fix it.

