### PR TITLE
Remove unnecessary idpHint check

### DIFF
--- a/vue/sbc-common-components/package.json
+++ b/vue/sbc-common-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sbc-common-components",
-  "version": "2.1.17",
+  "version": "2.1.18",
   "private": false,
   "description": "Common Vue Components to be used across SBC projects",
   "license": "Apache-2.0",

--- a/vue/sbc-common-components/src/components/SbcSignin.vue
+++ b/vue/sbc-common-components/src/components/SbcSignin.vue
@@ -54,18 +54,16 @@ export default class SbcSignin extends Vue {
           KeyCloakService.initSession()
           // emitting event for the header to get updated with :key increment from the parent component
           this.$emit('keycloak-session-ready')
-          if (this.idpHint === 'bcsc' || this.idpHint === 'idir') {
-            // tell KeycloakServices to load the user info
-            this.loadUserInfo()
-            // sync the account if there is one
-            await this.syncAccount()
-            this.$emit('sync-user-profile-ready')
-            // eslint-disable-next-line no-console
-            console.info('[SignIn.vue]Logged in User.Starting refreshTimer')
-            let tokenService = new TokenService()
-            await tokenService.init()
-            tokenService.scheduleRefreshTimer()
-          }
+          // tell KeycloakServices to load the user info
+          this.loadUserInfo()
+          // sync the account if there is one
+          await this.syncAccount()
+          this.$emit('sync-user-profile-ready')
+          // eslint-disable-next-line no-console
+          console.info('[SignIn.vue]Logged in User.Starting refreshTimer')
+          let tokenService = new TokenService()
+          await tokenService.init()
+          tokenService.scheduleRefreshTimer()
           resolve()
         }
       })


### PR DESCRIPTION
Patch 2.1.18

* Remove check on SbcSignin for login source that was preventing loading of user profile information for BCROS sources (director search).