### PR TITLE
Add config key check for AUTH_API_URL

### DIFF
--- a/vue/sbc-common-components/package.json
+++ b/vue/sbc-common-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sbc-common-components",
-  "version": "2.1.19",
+  "version": "2.1.20",
   "private": false,
   "description": "Common Vue Components to be used across SBC projects",
   "license": "Apache-2.0",

--- a/vue/sbc-common-components/src/util/config-helper.ts
+++ b/vue/sbc-common-components/src/util/config-helper.ts
@@ -25,10 +25,7 @@ export default class ConfigHelper {
 
   static getAuthAPIUrl (): string {
     const apiConfig = JSON.parse(sessionStorage.getItem(SessionStorageKeys.ApiConfigKey) || '{}')
-    if (apiConfig) {
-      return apiConfig['VUE_APP_AUTH_ROOT_API'] || apiConfig['AUTH_API_URL'] || ''
-    }
-    return ''
+    return (apiConfig && apiConfig['VUE_APP_AUTH_ROOT_API']) || sessionStorage.getItem(SessionStorageKeys.AuthApiUrl) || ''
   }
 
   static getAuthContextPath (): string {

--- a/vue/sbc-common-components/src/util/config-helper.ts
+++ b/vue/sbc-common-components/src/util/config-helper.ts
@@ -25,7 +25,10 @@ export default class ConfigHelper {
 
   static getAuthAPIUrl (): string {
     const apiConfig = JSON.parse(sessionStorage.getItem(SessionStorageKeys.ApiConfigKey) || '{}')
-    return apiConfig ? apiConfig['VUE_APP_AUTH_ROOT_API'] : ''
+    if (apiConfig) {
+      return apiConfig['VUE_APP_AUTH_ROOT_API'] || apiConfig['AUTH_API_URL'] || ''
+    }
+    return ''
   }
 
   static getAuthContextPath (): string {

--- a/vue/sbc-common-components/src/util/constants.ts
+++ b/vue/sbc-common-components/src/util/constants.ts
@@ -8,5 +8,6 @@ export enum SessionStorageKeys {
   PreventStorageSync = 'PREVENT_STORAGE_SYNC',
   UserAccountType = 'USER_ACCOUNT_TYPE',
   LaunchDarklyFlags = 'LD_FLAGS',
-  CurrentAccount = 'CURRENT_ACCOUNT'
+  CurrentAccount = 'CURRENT_ACCOUNT',
+  AuthApiUrl = 'AUTH_API_URL'
 }


### PR DESCRIPTION
Filings UI uses AUTH_API_URL in their config map.  This change checks for that key if VUE_APP_AUTH_ROOT_API is not present.  Fixes console errors when pulling account settings from auth-api.