### PR TITLE
Change conflicting method name (vuex)

### DIFF
--- a/vue/sbc-common-components/package.json
+++ b/vue/sbc-common-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sbc-common-components",
-  "version": "2.1.25",
+  "version": "2.1.26",
   "private": false,
   "description": "Common Vue Components to be used across SBC projects",
   "license": "Apache-2.0",

--- a/vue/sbc-common-components/package.json
+++ b/vue/sbc-common-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sbc-common-components",
-  "version": "2.1.26",
+  "version": "2.1.27",
   "private": false,
   "description": "Common Vue Components to be used across SBC projects",
   "license": "Apache-2.0",

--- a/vue/sbc-common-components/src/components/NavigationBar.vue
+++ b/vue/sbc-common-components/src/components/NavigationBar.vue
@@ -69,17 +69,17 @@ import { UserSettings } from '../models/userSettings'
 @Component({
   name: 'NavigationBar',
   beforeCreate () {
-    this.$store.hasModule = function (aPath: string[]) {
+    this.$store.isModuleRegistered = function (aPath: string[]) {
       let m = (this as any)._modules.root
       return aPath.every((p) => {
         m = m._children[p]
         return m
       })
     }
-    if (!this.$store.hasModule(['account'])) {
+    if (!this.$store.isModuleRegistered(['account'])) {
       this.$store.registerModule('account', AccountModule)
     }
-    if (!this.$store.hasModule(['auth'])) {
+    if (!this.$store.isModuleRegistered(['auth'])) {
       this.$store.registerModule('auth', AuthModule)
     }
     this.$options.computed = {

--- a/vue/sbc-common-components/src/components/PaySystemAlert.vue
+++ b/vue/sbc-common-components/src/components/PaySystemAlert.vue
@@ -26,14 +26,14 @@ declare module 'vuex' {
     SbcSystemBanner
   },
   beforeCreate () {
-    this.$store.hasModule = function (aPath: string[]) {
+    this.$store.isModuleRegistered = function (aPath: string[]) {
       let m = (this as any)._modules.root
       return aPath.every((p) => {
         m = m._children[p]
         return m
       })
     }
-    if (!this.$store.hasModule(['status'])) {
+    if (!this.$store.isModuleRegistered(['status'])) {
       this.$store.registerModule('status', StatusModule)
     }
     this.$options.computed = {

--- a/vue/sbc-common-components/src/components/SbcHeader.vue
+++ b/vue/sbc-common-components/src/components/SbcHeader.vue
@@ -147,23 +147,23 @@ import SbcProductSelector from './SbcProductSelector.vue'
 
 declare module 'vuex' {
   interface Store<S> {
-    hasModule(_: string[]): boolean
+    isModuleRegistered(_: string[]): boolean
   }
 }
 
 @Component({
   beforeCreate () {
-    this.$store.hasModule = function (aPath: string[]) {
+    this.$store.isModuleRegistered = function (aPath: string[]) {
       let m = (this as any)._modules.root
       return aPath.every((p) => {
         m = m._children[p]
         return m
       })
     }
-    if (!this.$store.hasModule(['account'])) {
+    if (!this.$store.isModuleRegistered(['account'])) {
       this.$store.registerModule('account', AccountModule)
     }
-    if (!this.$store.hasModule(['auth'])) {
+    if (!this.$store.isModuleRegistered(['auth'])) {
       this.$store.registerModule('auth', AuthModule)
     }
     this.$options.computed = {

--- a/vue/sbc-common-components/src/components/SbcProductSelector.vue
+++ b/vue/sbc-common-components/src/components/SbcProductSelector.vue
@@ -75,14 +75,14 @@ import { getModule } from 'vuex-module-decorators'
 @Component({
   name: 'SbcProductSelector',
   beforeCreate () {
-    this.$store.hasModule = function (aPath: string[]) {
+    this.$store.isModuleRegistered = function (aPath: string[]) {
       let m = (this as any)._modules.root
       return aPath.every((p) => {
         m = m._children[p]
         return m
       })
     }
-    if (!this.$store.hasModule(['product'])) {
+    if (!this.$store.isModuleRegistered(['product'])) {
       this.$store.registerModule('product', ProductModule)
     }
     this.$options.computed = {

--- a/vue/sbc-common-components/src/components/SbcSignin.vue
+++ b/vue/sbc-common-components/src/components/SbcSignin.vue
@@ -17,17 +17,17 @@ import { KCUserProfile } from '../models/KCUserProfile'
     LoadingScreen
   },
   beforeCreate () {
-    this.$store.hasModule = function (aPath: string[]) {
+    this.$store.isModuleRegistered = function (aPath: string[]) {
       let m = (this as any)._modules.root
       return aPath.every((p) => {
         m = m._children[p]
         return m
       })
     }
-    if (!this.$store.hasModule(['account'])) {
+    if (!this.$store.isModuleRegistered(['account'])) {
       this.$store.registerModule('account', AccountModule)
     }
-    if (!this.$store.hasModule(['auth'])) {
+    if (!this.$store.isModuleRegistered(['auth'])) {
       this.$store.registerModule('auth', AuthModule)
     }
     this.$options.methods = {


### PR DESCRIPTION
Patch 2.1.27: Temporary fix to conflicting method name when using Vuex 3.2.0 +

This temporary fix will be used until confirmed all consuming applications are at 3.2 or higher.