### PR TITLE
added optional About tooltip to footer

### DIFF
--- a/vue/sbc-common-components/package-lock.json
+++ b/vue/sbc-common-components/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sbc-common-components",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/vue/sbc-common-components/package.json
+++ b/vue/sbc-common-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sbc-common-components",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "private": false,
   "description": "Common Vue Components to be used across BC Registries projects.",
   "license": "Apache-2.0",

--- a/vue/sbc-common-components/src/components/SbcFooter.vue
+++ b/vue/sbc-common-components/src/components/SbcFooter.vue
@@ -9,17 +9,26 @@
           <li><a href="https://www2.gov.bc.ca/gov/content/home/accessibility" target="_blank">Accessibility</a></li>
           <li><a href="https://www2.gov.bc.ca/gov/content/home/copyright" target="_blank">Copyright</a></li>
         </ul>
+        <v-tooltip left nudge-top="30" v-if="aboutText" attach=".app-footer">
+          <template v-slot:activator="{ on, attrs }">
+            <v-icon icon v-bind="attrs" v-on="on" color="#8099b3">mdi-information-outline</v-icon>
+          </template>
+          <div v-html="aboutText"></div>
+        </v-tooltip>
       </nav>
     </div>
   </footer>
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
+import { Component, Vue, Prop } from 'vue-property-decorator'
 
-export default Vue.extend({
-  name: 'sbc-footer'
-})
+@Component({})
+export default class SbcFooter extends Vue {
+  /** Optional About text. */
+  @Prop({ default: '' })
+  private aboutText: string
+}
 </script>
 
 <style lang="scss" scoped>
@@ -35,8 +44,10 @@ export default Vue.extend({
   }
 
   nav {
+    display: flex;
+    justify-content: space-between;
+
     ul {
-      margin: -0.5rem;
       padding: 0;
       list-style-type: none;
     }
@@ -72,6 +83,15 @@ export default Vue.extend({
           padding: 0.25rem 0.5rem;
         }
       }
+    }
+  }
+
+  // make the tooltip opaque
+  .v-tooltip__content {
+    background: rgba($BCgovBlue3, 1) !important;
+
+    &.menuable__content__active {
+      opacity: 1!important;
     }
   }
 </style>


### PR DESCRIPTION
*Issue #:* /bcgov/entity#2555

*Description of changes:*
- added tooltip to optionally show About text
- updated app version

*Screenshots:*
The information icon:
![icon](https://user-images.githubusercontent.com/10002889/90693619-0182a900-e22c-11ea-86db-a961c250f42f.png)

The tooltip (when hovering over the icon):
![tooltip](https://user-images.githubusercontent.com/10002889/90693637-0a737a80-e22c-11ea-84e3-d3b8e6bee2e1.png)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).