### PR TITLE
4780: Update user profile only during login

### DIFF
--- a/vue/sbc-common-components/package.json
+++ b/vue/sbc-common-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sbc-common-components",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "private": false,
   "description": "Common Vue Components to be used across BC Registries projects.",
   "license": "Apache-2.0",

--- a/vue/sbc-common-components/src/components/SbcSignin.vue
+++ b/vue/sbc-common-components/src/components/SbcSignin.vue
@@ -37,7 +37,8 @@ import NavigationMixin from '../mixins/navigation-mixin'
       ...mapActions('account', [
         'loadUserInfo',
         'syncAccount',
-        'getCurrentUserProfile'
+        'getCurrentUserProfile',
+        'updateUserProfile'
       ])
     }
   }
@@ -50,6 +51,7 @@ export default class SbcSignin extends NavigationMixin {
   private readonly loadUserInfo!: () => KCUserProfile
   private readonly syncAccount!: () => Promise<void>
   private readonly getCurrentUserProfile!: (isAuth: boolean) => Promise<any>
+  private readonly updateUserProfile!: () => Promise<void>
 
   private async mounted () {
     getModule(AccountModule, this.$store)
@@ -64,6 +66,10 @@ export default class SbcSignin extends NavigationMixin {
           await KeyCloakService.initSession()
           // tell KeycloakServices to load the user info
           const userInfo = await this.loadUserInfo()
+
+          //update user profile
+          await this.updateUserProfile()
+
           // sync the account if there is one
           await this.syncAccount()
 

--- a/vue/sbc-common-components/src/services/user.services.ts
+++ b/vue/sbc-common-components/src/services/user.services.ts
@@ -9,4 +9,8 @@ export default class UserService {
   static async getUserProfile (identifier: string): Promise<AxiosResponse<UserProfile>> {
     return axios.get(`${ConfigHelper.getAuthAPIUrl()}/users/${identifier}`)
   }
+
+  static async updateUserProfile (): Promise<AxiosResponse<UserProfile>> {
+    return axios.post(`${ConfigHelper.getAuthAPIUrl()}/users`, {'isLogin': true})
+  }
 }

--- a/vue/sbc-common-components/src/store/modules/account.ts
+++ b/vue/sbc-common-components/src/store/modules/account.ts
@@ -149,4 +149,9 @@ export default class AccountModule extends VuexModule {
         }
     }
   }
+
+  @Action({ rawError: true })
+  public async updateUserProfile () {
+    await UserService.updateUserProfile()
+  }
 }


### PR DESCRIPTION
v2.3.4

Issue:
User Profile is not updated during login, which makes it hard to audit user session start time.
https://github.com/bcgov/entity/issues/4780

Fix:
Added updateUserProfile on successful login.