### PR TITLE
fix for SbcAuthenticationOptions redirection from non sbc-auth applications

### DIFF
--- a/vue/sbc-common-components/package-lock.json
+++ b/vue/sbc-common-components/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sbc-common-components",
-  "version": "2.3.4",
+  "version": "2.3.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/vue/sbc-common-components/package.json
+++ b/vue/sbc-common-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sbc-common-components",
-  "version": "2.3.4",
+  "version": "2.3.5",
   "private": false,
   "description": "Common Vue Components to be used across BC Registries and Online Services.",
   "license": "Apache-2.0",

--- a/vue/sbc-common-components/src/components/SbcAuthenticationOptions.vue
+++ b/vue/sbc-common-components/src/components/SbcAuthenticationOptions.vue
@@ -86,7 +86,7 @@ export default class SbcAuthenticationOptions extends NavigationMixin {
     if (this.redirectUrl?.trim()) {
       signinRoute += `/${encodeURIComponent(this.redirectUrl.trim())}`
     }
-    this.redirectToPath(this.inAuth, signinRoute)
+    this.redirectInTriggeredApp(signinRoute)
   }
 
   private goToCreateAccount () {

--- a/vue/sbc-common-components/src/mixins/navigation-mixin.ts
+++ b/vue/sbc-common-components/src/mixins/navigation-mixin.ts
@@ -5,13 +5,18 @@ import ConfigHelper from '../util/config-helper'
 export default class NavigationMixin extends Vue {
   protected redirectToPath (inAuth: boolean, routePath: string) {
     if (inAuth) {
-      const resolvedRoutes = this.$router.resolve({ path: `/${routePath}` })
-      if (resolvedRoutes.resolved.matched.length > 0) {
-        this.$router.push(`/${routePath}`)
-      } else {
-        window.location.assign(`${ConfigHelper.getAuthContextPath()}/${routePath}`)
-      }
+      this.redirectInTriggeredApp(routePath)
     } else {
+      window.location.assign(`${ConfigHelper.getAuthContextPath()}/${routePath}`)
+    }
+  }
+
+  protected redirectInTriggeredApp (routePath: string) {
+    const resolvedRoutes = this.$router.resolve({ path: `/${routePath}` })
+    if (resolvedRoutes.resolved.matched.length > 0) {
+      this.$router.push(`/${routePath}`)
+    } else {
+      // navigate to auth app if route is not found in the triggered app
       window.location.assign(`${ConfigHelper.getAuthContextPath()}/${routePath}`)
     }
   }


### PR DESCRIPTION
- fix for redirection from non sbc-auth applications

The signin redirection in the SbcAuthenticationOptions component is currently always going to the sbc-auth application. which is preventing to use the events and control of the signin view component in the other apps.
This fix is for redirection to happen in the same application and auth url as a fallback if the route provided is invalid