### PR TITLE
Removed Comment causing build errors

### DIFF
--- a/vue/sbc-common-components/package-lock.json
+++ b/vue/sbc-common-components/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sbc-common-components",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/vue/sbc-common-components/package.json
+++ b/vue/sbc-common-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sbc-common-components",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "private": false,
   "description": "Common Vue Components to be used across BC Registries and Online Services.",
   "license": "Apache-2.0",

--- a/vue/sbc-common-components/src/components/SbcProductSelector.vue
+++ b/vue/sbc-common-components/src/components/SbcProductSelector.vue
@@ -188,7 +188,7 @@ section + section {
 .app-header {
   z-index: 2;
   position: sticky;
-  position: -webkit-sticky; //Safari
+  position: -webkit-sticky;
   top: 0;
   width: 100%;
   height: 70px;


### PR DESCRIPTION
*Issue #:* /bcgov/entity#5328

*Description of changes:*

* Removed comment in SbcProducSelector that was causing a build error in the Sass loader in NameRequest, when attempting to import SbcHeader.