### PR TITLE
Implemented Disable Action Prop for SBC-Header

### DIFF
--- a/vue/sbc-common-components/package.json
+++ b/vue/sbc-common-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sbc-common-components",
-  "version": "2.4.5",
+  "version": "2.4.6",
   "private": false,
   "description": "Common Vue Components to be used across BC Registries and Online Services.",
   "license": "Apache-2.0",

--- a/vue/sbc-common-components/src/components/SbcHeader.vue
+++ b/vue/sbc-common-components/src/components/SbcHeader.vue
@@ -14,7 +14,7 @@
         </picture>
         <span class="brand__title">BC Registries <span class="brand__title--wrap">and Online Services</span></span>
       </a>
-      <div class="app-header__actions">
+      <div v-if="!disableActions" class="app-header__actions">
 
         <!-- Product Selector -->
         <sbc-product-selector v-if="showProductSelector" />
@@ -364,6 +364,7 @@ export default class SbcHeader extends Mixins(NavigationMixin) {
   @Prop({ default: '' }) redirectOnLogout!: string;
   @Prop({ default: false }) inAuth!: boolean;
   @Prop({ default: false }) showProductSelector!: boolean;
+  @Prop({ default: false }) disableActions!: boolean;
 
   private readonly loginOptions = [
     {

--- a/vue/sbc-common-components/src/components/SbcHeader.vue
+++ b/vue/sbc-common-components/src/components/SbcHeader.vue
@@ -14,7 +14,7 @@
         </picture>
         <span class="brand__title">BC Registries <span class="brand__title--wrap">and Online Services</span></span>
       </a>
-      <div v-if="!disableActions" class="app-header__actions">
+      <div v-if="showActions" class="app-header__actions">
 
         <!-- Product Selector -->
         <sbc-product-selector v-if="showProductSelector" />
@@ -364,7 +364,7 @@ export default class SbcHeader extends Mixins(NavigationMixin) {
   @Prop({ default: '' }) redirectOnLogout!: string;
   @Prop({ default: false }) inAuth!: boolean;
   @Prop({ default: false }) showProductSelector!: boolean;
-  @Prop({ default: false }) disableActions!: boolean;
+  @Prop({ default: true }) showActions!: boolean;
 
   private readonly loginOptions = [
     {


### PR DESCRIPTION
* Implemented disable prop for SBC Header Actions

*Notes:*

* In Name Request, we wanted to hide the actions as a whole until the functionality is ready on the Namex Side.