### PR TITLE
User in-app notification of suspended account

### DIFF
--- a/vue/sbc-common-components/package-lock.json
+++ b/vue/sbc-common-components/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sbc-common-components",
-  "version": "2.4.5",
+  "version": "2.4.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/vue/sbc-common-components/package.json
+++ b/vue/sbc-common-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sbc-common-components",
-  "version": "2.4.6",
+  "version": "2.4.7",
   "private": false,
   "description": "Common Vue Components to be used across BC Registries and Online Services.",
   "license": "Apache-2.0",

--- a/vue/sbc-common-components/src/components/SbcHeader.vue
+++ b/vue/sbc-common-components/src/components/SbcHeader.vue
@@ -408,6 +408,8 @@ export default class SbcHeader extends Mixins(NavigationMixin) {
       await this.loadUserInfo()
       await this.syncAccount()
       await this.updateProfile()
+      // checking for account status
+      await this.checkAccountStatus()
     }
   }
 
@@ -460,6 +462,13 @@ export default class SbcHeader extends Mixins(NavigationMixin) {
       return
     }
     this.redirectToPath(this.inAuth, `${Pages.ACCOUNT}/${this.currentAccount.id}/${Pages.SETTINGS}/transactions`)
+  }
+
+  private checkAccountStatus () {
+    // redirect if accoutn status is suspended
+    if (this.currentAccount?.accountStatus && this.currentAccount?.accountStatus === 'NSF_SUSPENDED') {
+      this.redirectToPath(this.inAuth, `${Pages.ACCOUNT_FREEZ}`)
+    }
   }
 
   private async switchAccount (settings: UserSettings, inAuth?: boolean) {

--- a/vue/sbc-common-components/src/models/userSettings.ts
+++ b/vue/sbc-common-components/src/models/userSettings.ts
@@ -5,4 +5,5 @@ export interface UserSettings {
   urlpath: string
   urlorigin: string
   accountType: string // will be only present for accounts
+  accountStatus: string
 }

--- a/vue/sbc-common-components/src/util/constants.ts
+++ b/vue/sbc-common-components/src/util/constants.ts
@@ -44,5 +44,6 @@ export enum Pages {
   USER_PROFILE_TERMS = 'userprofileterms',
   CREATE_ACCOUNT = 'setup-account',
   CHOOSE_AUTH_METHOD = 'choose-authentication-method',
-  NON_BCSC_INSTRUCTIONS = 'nonbcsc-info/instructions'
+  NON_BCSC_INSTRUCTIONS = 'nonbcsc-info/instructions',
+  ACCOUNT_FREEZ = 'account-freeze'
 }


### PR DESCRIPTION
Issue #: bcgov/entity#5229

Description of changes:
* If the account is suspended status, the user will redirect to the account-freeze page according to role
* updated version 2.4.6 to 2.4.7

