### PR TITLE
launch darkly flags are getting cached | removed check from session

### DIFF
--- a/vue/sbc-common-components/package-lock.json
+++ b/vue/sbc-common-components/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sbc-common-components",
-  "version": "2.4.10",
+  "version": "2.4.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/vue/sbc-common-components/package.json
+++ b/vue/sbc-common-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sbc-common-components",
-  "version": "2.4.10",
+  "version": "2.4.11",
   "private": false,
   "description": "Common Vue Components to be used across BC Registries and Online Services.",
   "license": "Apache-2.0",

--- a/vue/sbc-common-components/src/services/launchdarkly.services.ts
+++ b/vue/sbc-common-components/src/services/launchdarkly.services.ts
@@ -28,22 +28,17 @@ class LaunchDarklyService {
   init (ldEnvKey: string) {
     var user = { 'anonymous': true }
 
-    if (!this.isFlagsAvailable) {
-      this.ldClient = initialize(ldEnvKey, user)
+    this.ldClient = initialize(ldEnvKey, user)
 
-      return new Promise((resolve) => {
-        this.ldClient.on('initialized', () => {
-          this.setFlags(this.ldClient.allFlags())
-          resolve()
-        })
-        this.ldClient.on('failed', () => {
-          this.setFlags(defaultFlagSet)
-          resolve()
-        })
-      })
-    }
     return new Promise((resolve) => {
-      resolve()
+      this.ldClient.on('initialized', () => {
+        this.setFlags(this.ldClient.allFlags())
+        resolve()
+      })
+      this.ldClient.on('failed', () => {
+        this.setFlags(defaultFlagSet)
+        resolve()
+      })
     })
   }
 


### PR DESCRIPTION
* Call launchdarkly on reload. 
* Removed check from session to avoid caching