### PR TITLE
Feature/Relationship #6921changes on Sbc-Header

### DIFF
--- a/vue/sbc-common-components/package-lock.json
+++ b/vue/sbc-common-components/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sbc-common-components",
-  "version": "2.4.16",
+  "version": "2.4.17",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/vue/sbc-common-components/package.json
+++ b/vue/sbc-common-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sbc-common-components",
-  "version": "2.4.16",
+  "version": "2.4.17",
   "private": false,
   "description": "Common Vue Components to be used across BC Registries and Online Services.",
   "license": "Apache-2.0",

--- a/vue/sbc-common-components/src/components/SbcHeader.vue
+++ b/vue/sbc-common-components/src/components/SbcHeader.vue
@@ -455,14 +455,8 @@ export default class SbcHeader extends Mixins(NavigationMixin) {
   }
 
   private goToCreateBCSCAccount () {
-    if (this.inAuth) {
-      this.$router.push(`/${Pages.CREATE_ACCOUNT}`)
-    } else {
-      // To send the navigateBackUrl to duplicate account creator interceptor screen, so that we can redirect to that page.
-      let redirectUrl = new URL(`${ConfigHelper.getAuthContextPath()}/${Pages.CREATE_ACCOUNT}`)
-      if (this.dashboardReturnUrl) redirectUrl.searchParams.append('redirectToUrl', encodeURIComponent(this.dashboardReturnUrl))
-      window.location.assign(redirectUrl.toString())
-    }
+    const redirectUrl: string = this.dashboardReturnUrl ? `${Pages.CREATE_ACCOUNT}?redirectToUrl=${encodeURIComponent(this.dashboardReturnUrl)}` : Pages.CREATE_ACCOUNT
+    this.redirectToPath(this.inAuth, redirectUrl)
   }
 
   private async goToAccountInfo (settings: UserSettings) {

--- a/vue/sbc-common-components/src/components/SbcHeader.vue
+++ b/vue/sbc-common-components/src/components/SbcHeader.vue
@@ -374,6 +374,7 @@ export default class SbcHeader extends Mixins(NavigationMixin) {
   @Prop({ default: false }) inAuth!: boolean;
   @Prop({ default: false }) showProductSelector!: boolean;
   @Prop({ default: true }) showActions!: boolean;
+  @Prop({ default: '' }) dashboardReturnUrl !: string;
 
   private readonly loginOptions = [
     {
@@ -454,7 +455,14 @@ export default class SbcHeader extends Mixins(NavigationMixin) {
   }
 
   private goToCreateBCSCAccount () {
-    this.redirectToPath(this.inAuth, Pages.CREATE_ACCOUNT)
+    if (this.inAuth) {
+      this.$router.push(`/${Pages.CREATE_ACCOUNT}`)
+    } else {
+      // To send the navigateBackUrl to duplicate account creator interceptor screen, so that we can redirect to that page.
+      let redirectUrl = new URL(`${ConfigHelper.getAuthContextPath()}/${Pages.CREATE_ACCOUNT}`)
+      if (this.dashboardReturnUrl) redirectUrl.searchParams.append('redirectToUrl', encodeURIComponent(this.dashboardReturnUrl))
+      window.location.assign(redirectUrl.toString())
+    }
   }
 
   private async goToAccountInfo (settings: UserSettings) {


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/6921

*Description of changes:*

- Updated Sbc-header component to accept a dashboardReturnUrl property that would be passed on while clicking "create account" to the Sbc-Auth so that can be used while displaying the Duplicate account warning page.
- Updated package version to 2.4.17

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).