### PR TITLE
1password keys integration.

### DIFF
--- a/vue/sbc-common-components/package-lock.json
+++ b/vue/sbc-common-components/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sbc-common-components",
-  "version": "2.4.18",
+  "version": "2.4.19",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/vue/sbc-common-components/package.json
+++ b/vue/sbc-common-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sbc-common-components",
-  "version": "2.4.18",
+  "version": "2.4.19",
   "private": false,
   "description": "Common Vue Components to be used across BC Registries and Online Services.",
   "license": "Apache-2.0",

--- a/vue/sbc-common-components/src/util/config-helper.ts
+++ b/vue/sbc-common-components/src/util/config-helper.ts
@@ -20,18 +20,15 @@ export default class ConfigHelper {
   }
 
   static getStatusAPIUrl (): string {
-    const apiConfig = JSON.parse(sessionStorage.getItem(SessionStorageKeys.ApiConfigKey) || '{}')
-    return trimTrailingSlashURL(apiConfig ? apiConfig['VUE_APP_STATUS_ROOT_API'] : '')
+    return trimTrailingSlashURL(sessionStorage.getItem(SessionStorageKeys.StatusApiUrl) || '')
   }
 
   static getAuthAPIUrl (): string {
-    const apiConfig = JSON.parse(sessionStorage.getItem(SessionStorageKeys.ApiConfigKey) || '{}')
-    return trimTrailingSlashURL((apiConfig && apiConfig['VUE_APP_AUTH_ROOT_API']) || sessionStorage.getItem(SessionStorageKeys.AuthApiUrl) || '')
+    return trimTrailingSlashURL(sessionStorage.getItem(SessionStorageKeys.AuthApiUrl) || '')
   }
 
   static getAuthContextPath (): string {
-    const apiConfig = JSON.parse(sessionStorage.getItem(SessionStorageKeys.ApiConfigKey) || '{}')
-    return trimTrailingSlashURL((apiConfig && apiConfig['AUTH_URL']) || sessionStorage.getItem('AUTH_URL') || '')
+    return trimTrailingSlashURL(sessionStorage.getItem(SessionStorageKeys.AuthWebUrl) || '')
   }
 
   static setKeycloakConfigUrl (keycloakConfigUrl: string) {

--- a/vue/sbc-common-components/src/util/constants.ts
+++ b/vue/sbc-common-components/src/util/constants.ts
@@ -7,6 +7,8 @@ export enum SessionStorageKeys {
   LaunchDarklyFlags = 'LD_FLAGS',
   CurrentAccount = 'CURRENT_ACCOUNT',
   AuthApiUrl = 'AUTH_API_URL',
+  AuthWebUrl = 'AUTH_WEB_URL',
+  StatusApiUrl = 'STATUS_API_URL',
   SessionSynced = 'SESSION_SYNCED'
 }
 


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/7849
https://github.com/bcgov/entity/issues/6801

*Description of changes:*
1. change the key new to match new configuration of 1password.
2. change to read the session keys directly instead of read from auth-api-config session key.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
