### PR TITLE
12496 - Add in exception handling logging. 

### DIFF
--- a/python/src/sbc_common_components/exception_handling/exception_handler.py
+++ b/python/src/sbc_common_components/exception_handling/exception_handler.py
@@ -37,8 +37,11 @@ class ExceptionHandler():
     def db_handler(self, error):  # pylint: disable=no-self-use
         """Handle Database error."""
         logger.exception(error)
-        return {'error': '{}'.format(error.__dict__['code']),
-                'message': '{}'.format(str(error.__dict__['orig']))}, error.status_code, RESPONSE_HEADERS
+        error_code = error.__dict__['code'] if hasattr(error.__dict__, 'code') else type(error).__name__
+        message = str(error.__dict__['orig']) if hasattr(error.__dict__, 'orig') else ''
+        status_code = error.status_code if hasattr(error, 'status_code') else 500
+        return {'error': '{}'.format(error_code),
+                'message': '{}'.format(message)}, status_code, RESPONSE_HEADERS
 
     def std_handler(self, error):  # pylint: disable=no-self-use
         """Handle standard exception."""

--- a/python/src/sbc_common_components/exception_handling/exception_handler.py
+++ b/python/src/sbc_common_components/exception_handling/exception_handler.py
@@ -60,7 +60,6 @@ class ExceptionHandler():
         """Register common exceptons or errors."""
         self.app = app
         self.register(AuthError, self.auth_handler)
-        self.register(HTTPException)
         self.register(SQLAlchemyError, self.db_handler)
         self.register(Exception)
         for exception in default_exceptions:

--- a/python/src/sbc_common_components/exception_handling/exception_handler.py
+++ b/python/src/sbc_common_components/exception_handling/exception_handler.py
@@ -37,10 +37,10 @@ class ExceptionHandler():
     def db_handler(self, error):  # pylint: disable=no-self-use
         """Handle Database error."""
         logger.exception(error)
-        error_code = error.__dict__['code'] if hasattr(error.__dict__, 'code') else type(error).__name__
-        message = str(error.__dict__['orig']) if hasattr(error.__dict__, 'orig') else ''
+        error_text = error.__dict__['code'] if hasattr(error.__dict__, 'code') else ''
+        message = str(error.__dict__['orig']) if hasattr(error.__dict__, 'orig') else 'Internal server error'
         status_code = error.status_code if hasattr(error, 'status_code') else 500
-        return {'error': '{}'.format(error_code),
+        return {'error': '{}'.format(error_text),
                 'message': '{}'.format(message)}, status_code, RESPONSE_HEADERS
 
     def std_handler(self, error):  # pylint: disable=no-self-use

--- a/python/src/sbc_common_components/exception_handling/exception_handler.py
+++ b/python/src/sbc_common_components/exception_handling/exception_handler.py
@@ -42,18 +42,12 @@ class ExceptionHandler():
 
     def std_handler(self, error):  # pylint: disable=no-self-use
         """Handle standard exception."""
-        message_content = ''
-        if hasattr(error, 'message'):
-            message_content = error.message
-        elif hasattr(error, 'description'):
-            message_content = error.description
-        else:
-            message_content = '{0}'.format(error.args)
-        message = dict(messaage=message_content)
         if isinstance(error, HTTPException):
             logger.error(error)
+            message = dict(messaage=error.message if hasattr(error, 'message') else error.description)
         else:
             logger.exception(error)
+            message = dict(message='Internal server error')
         return message, error.code if isinstance(error, HTTPException) else 500, RESPONSE_HEADERS
 
     def init_app(self, app):

--- a/python/src/sbc_common_components/exception_handling/exception_handler.py
+++ b/python/src/sbc_common_components/exception_handling/exception_handler.py
@@ -42,7 +42,14 @@ class ExceptionHandler():
 
     def std_handler(self, error):  # pylint: disable=no-self-use
         """Handle standard exception."""
-        message = dict(messaage=error.message if hasattr(error, 'message') else error.description)
+        message_content = ''
+        if hasattr(error, 'message'):
+            message_content = error.message
+        elif hasattr(error, 'description'):
+            message_content = error.description
+        else:
+            message_content = '{0}'.format(error.args)
+        message = dict(messaage=message_content)
         if isinstance(error, HTTPException):
             logger.error(error)
         else:
@@ -55,6 +62,7 @@ class ExceptionHandler():
         self.register(AuthError, self.auth_handler)
         self.register(HTTPException)
         self.register(SQLAlchemyError, self.db_handler)
+        self.register(Exception)
         for exception in default_exceptions:
             self.register(self._get_exc_class_and_code(exception))
 

--- a/python/src/sbc_common_components/exception_handling/exception_handler.py
+++ b/python/src/sbc_common_components/exception_handling/exception_handler.py
@@ -47,7 +47,7 @@ class ExceptionHandler():
         """Handle standard exception."""
         if isinstance(error, HTTPException):
             logger.error(error)
-            message = dict(messaage=error.message if hasattr(error, 'message') else error.description)
+            message = dict(message=error.message if hasattr(error, 'message') else error.description)
         else:
             logger.exception(error)
             message = dict(message='Internal server error')

--- a/python/src/sbc_common_components/exception_handling/exception_handler.py
+++ b/python/src/sbc_common_components/exception_handling/exception_handler.py
@@ -38,10 +38,10 @@ class ExceptionHandler():
         """Handle Database error."""
         logger.exception(error)
         error_text = error.__dict__['code'] if hasattr(error.__dict__, 'code') else ''
-        message = str(error.__dict__['orig']) if hasattr(error.__dict__, 'orig') else 'Internal server error'
+        message_text = str(error.__dict__['orig']) if hasattr(error.__dict__, 'orig') else 'Internal server error'
         status_code = error.status_code if hasattr(error, 'status_code') else 500
         return {'error': '{}'.format(error_text),
-                'message': '{}'.format(message)}, status_code, RESPONSE_HEADERS
+                'message': '{}'.format(message_text)}, status_code, RESPONSE_HEADERS
 
     def std_handler(self, error):  # pylint: disable=no-self-use
         """Handle standard exception."""


### PR DESCRIPTION
https://github.com/bcgov/entity/issues/12496

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).


This way it will display in the logs, and not just be sent over sentry.

In Openshift logs nothing is logged. Although I did get two emails from sentry:
AttributeError: 'NoneType' object has no attribute 'requested_by'

I've reviewed the sentry usage here:
https://docs.sentry.io/platforms/python/guides/logging/

I think it should work fine with sentry still, but wont know until it's on TEST. 

Before (in local dev): ***NOTE THIS DOESNT SHOW UP ON DEV/TEST environment, it's just blank***
```
Traceback (most recent call last):
  File "/home/trav/work/sbc-pay/pay-api/venv/lib/python3.8/site-packages/flask/app.py", line 2464, in __call__
    return self.wsgi_app(environ, start_response)
  File "/home/trav/work/sbc-pay/pay-api/venv/lib/python3.8/site-packages/flask/app.py", line 2450, in wsgi_app
    response = self.handle_exception(e)
  File "/home/trav/work/sbc-pay/pay-api/venv/lib/python3.8/site-packages/flask_restx/api.py", line 672, in error_router
    return original_handler(e)
  File "/home/trav/work/sbc-pay/pay-api/venv/lib/python3.8/site-packages/flask_restx/api.py", line 671, in error_router
    return original_handler(f)
  File "/home/trav/work/sbc-pay/pay-api/venv/lib/python3.8/site-packages/flask/app.py", line 1867, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/home/trav/work/sbc-pay/pay-api/venv/lib/python3.8/site-packages/flask/_compat.py", line 39, in reraise
    raise value
  File "/home/trav/work/sbc-pay/pay-api/venv/lib/python3.8/site-packages/flask_restx/api.py", line 669, in error_router
    return self.handle_error(e)
  File "/home/trav/work/sbc-pay/pay-api/venv/lib/python3.8/site-packages/flask/app.py", line 2447, in wsgi_app
    response = self.full_dispatch_request()
  File "/home/trav/work/sbc-pay/pay-api/venv/lib/python3.8/site-packages/flask/app.py", line 1952, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/home/trav/work/sbc-pay/pay-api/venv/lib/python3.8/site-packages/flask_restx/api.py", line 672, in error_router
    return original_handler(e)
  File "/home/trav/work/sbc-pay/pay-api/venv/lib/python3.8/site-packages/flask_restx/api.py", line 671, in error_router
    return original_handler(f)
  File "/home/trav/work/sbc-pay/pay-api/venv/lib/python3.8/site-packages/flask/app.py", line 1821, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/home/trav/work/sbc-pay/pay-api/venv/lib/python3.8/site-packages/flask/_compat.py", line 39, in reraise
    raise value
  File "/home/trav/work/sbc-pay/pay-api/venv/lib/python3.8/site-packages/flask_restx/api.py", line 669, in error_router
    return self.handle_error(e)
  File "/home/trav/work/sbc-pay/pay-api/venv/lib/python3.8/site-packages/flask/app.py", line 1950, in full_dispatch_request
    rv = self.dispatch_request()
  File "/home/trav/work/sbc-pay/pay-api/venv/lib/python3.8/site-packages/flask/app.py", line 1936, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/home/trav/work/sbc-pay/pay-api/venv/lib/python3.8/site-packages/flask_restx/api.py", line 403, in wrapper
    resp = resource(*args, **kwargs)
  File "/home/trav/work/sbc-pay/pay-api/venv/lib/python3.8/site-packages/flask/views.py", line 89, in view
    return self.dispatch_request(*args, **kwargs)
  File "/home/trav/work/sbc-pay/pay-api/venv/lib/python3.8/site-packages/flask_restx/resource.py", line 49, in dispatch_request
    resp = meth(*args, **kwargs)
  File "/home/trav/work/sbc-pay/pay-api/venv/lib/python3.8/site-packages/flask_restx/cors.py", line 45, in wrapped_function
    resp = make_response(f(*args, **kwargs))
  File "/home/trav/work/sbc-pay/pay-api/venv/lib/python3.8/site-packages/flask_jwt_oidc/jwt_manager.py", line 224, in wrapper
    return f(*args, **kwargs)
  File "/home/trav/work/sbc-pay/pay-api/venv/lib/python3.8/site-packages/flask_opentracing/tracing.py", line 82, in wrapper
    r = f(*args, **kwargs)
  File "/home/trav/work/sbc-pay/pay-api/src/pay_api/resources/fas/routing_slip.py", line 145, in patch
    response, status = RoutingSlipService.update(
  File "/home/trav/work/sbc-pay/pay-api/src/pay_api/utils/user_context.py", line 133, in wrapper
    return function(*func_args, **func_kwargs)
  File "/home/trav/work/sbc-pay/pay-api/src/pay_api/services/fas/routing_slip.py", line 396, in update
    RoutingSlipStatusTransitionService.validate_possible_transitions(routing_slip, status)
  File "/home/trav/work/sbc-pay/pay-api/src/pay_api/services/fas/routing_slip_status_transition_service.py", line 85, in validate_possible_transitions
    allowed_statuses = RoutingSlipStatusTransitionService.get_possible_transitions(rs_model)
  File "/home/trav/work/sbc-pay/pay-api/src/pay_api/utils/user_context.py", line 133, in wrapper
    return function(*func_args, **func_kwargs)
  File "/home/trav/work/sbc-pay/pay-api/src/pay_api/services/fas/routing_slip_status_transition_service.py", line 71, in get_possible_transitions
    is_same_user = refund_model.requested_by == kwargs['user'].user_name
AttributeError: 'NoneType' object has no attribute 'requested_by'

```

After:

```
2022-06-02 07:16:50,974 - pay_api - ERROR in app:app.py:1891 - log_exception: Exception on /api/v1/fas/routing-slips/298570860 [PATCH]
Traceback (most recent call last):
  File "/home/trav/work/sbc-pay/pay-api/venv/lib/python3.8/site-packages/flask/app.py", line 1950, in full_dispatch_request
    rv = self.dispatch_request()
  File "/home/trav/work/sbc-pay/pay-api/venv/lib/python3.8/site-packages/flask/app.py", line 1936, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/home/trav/work/sbc-pay/pay-api/venv/lib/python3.8/site-packages/flask_restx/api.py", line 403, in wrapper
    resp = resource(*args, **kwargs)
  File "/home/trav/work/sbc-pay/pay-api/venv/lib/python3.8/site-packages/flask/views.py", line 89, in view
    return self.dispatch_request(*args, **kwargs)
  File "/home/trav/work/sbc-pay/pay-api/venv/lib/python3.8/site-packages/flask_restx/resource.py", line 49, in dispatch_request
    resp = meth(*args, **kwargs)
  File "/home/trav/work/sbc-pay/pay-api/venv/lib/python3.8/site-packages/flask_restx/cors.py", line 45, in wrapped_function
    resp = make_response(f(*args, **kwargs))
  File "/home/trav/work/sbc-pay/pay-api/venv/lib/python3.8/site-packages/flask_jwt_oidc/jwt_manager.py", line 224, in wrapper
    return f(*args, **kwargs)
  File "/home/trav/work/sbc-pay/pay-api/venv/lib/python3.8/site-packages/flask_opentracing/tracing.py", line 82, in wrapper
    r = f(*args, **kwargs)
  File "/home/trav/work/sbc-pay/pay-api/src/pay_api/resources/fas/routing_slip.py", line 145, in patch
    response, status = RoutingSlipService.update(
  File "/home/trav/work/sbc-pay/pay-api/src/pay_api/utils/user_context.py", line 133, in wrapper
    return function(*func_args, **func_kwargs)
  File "/home/trav/work/sbc-pay/pay-api/src/pay_api/services/fas/routing_slip.py", line 396, in update
    RoutingSlipStatusTransitionService.validate_possible_transitions(routing_slip, status)
  File "/home/trav/work/sbc-pay/pay-api/src/pay_api/services/fas/routing_slip_status_transition_service.py", line 85, in validate_possible_transitions
    allowed_statuses = RoutingSlipStatusTransitionService.get_possible_transitions(rs_model)
  File "/home/trav/work/sbc-pay/pay-api/src/pay_api/utils/user_context.py", line 133, in wrapper
    return function(*func_args, **func_kwargs)
  File "/home/trav/work/sbc-pay/pay-api/src/pay_api/services/fas/routing_slip_status_transition_service.py", line 71, in get_possible_transitions
    is_same_user = refund_model.requested_by == kwargs['user'].user_name

