### PR TITLE
Added flex class so header height is maintained

### DIFF
--- a/vue/sbc-common-components/src/components/SbcHeader.vue
+++ b/vue/sbc-common-components/src/components/SbcHeader.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div class="d-flex">
     <header class="app-header" id="appHeader">
       <v-container class="justify-space-between">
         <a @click="goToHome()" class="brand">


### PR DESCRIPTION
*Issue #:* None

*Description of changes:*

While updating Filings UI and Create UI to Vue 2.7 (and related dependencies), I noticed that the SBC Header height was not being maintained correctly (ie, same as height of inner elements):

![image](https://user-images.githubusercontent.com/10002889/193112067-3c914171-eeda-484c-8a32-6037729c3207.png)

A temporary fix was to set the outer div to display=flex in Filings UI and Create UI, but this PR is a permanent fix.

This code does not need to be released right away, so I'm not updating the app version or planning to publish this fix -- it can go out with a future change to this library.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).