### PR TITLE
15202 - Auth-web allows incorrect province in contacts which causes e…

### DIFF
--- a/vue/sbc-common-components/package-lock.json
+++ b/vue/sbc-common-components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sbc-common-components",
-  "version": "3.0.7",
+  "version": "3.0.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "sbc-common-components",
-      "version": "3.0.7",
+      "version": "3.0.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@mdi/font": "^4.5.95",

--- a/vue/sbc-common-components/package.json
+++ b/vue/sbc-common-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sbc-common-components",
-  "version": "3.0.7",
+  "version": "3.0.8",
   "private": false,
   "description": "Common Vue Components to be used across BC Registries and Online Services.",
   "license": "Apache-2.0",

--- a/vue/sbc-common-components/src/components/BaseAddress.vue
+++ b/vue/sbc-common-components/src/components/BaseAddress.vue
@@ -227,7 +227,6 @@ export default class BaseAddress extends Mixins(ValidationMixin, CountriesProvin
     return this.addressLocal['addressCountry']
   }
 
-
   /** The Street Address Additional label with 'optional' as needed. */
   private get streetAddressAdditionalLabel (): string {
     return 'Additional Street Address' + (this.isSchemaRequired('streetAddressAdditional') ? '' : ' (Optional)')

--- a/vue/sbc-common-components/src/components/BaseAddress.vue
+++ b/vue/sbc-common-components/src/components/BaseAddress.vue
@@ -123,6 +123,7 @@
                     v-model="addressLocal.addressCountry"
                     :items="getCountries()"
                     :rules="[...rules.addressCountry, ...spaceRules]"
+                    v-on:change="resetRegion()"
           />
           <!-- special field to select AddressComplete country, separate from our model field -->
           <input type="hidden" :id="addressCountryId" :value="addressCountry" />
@@ -198,6 +199,10 @@ export default class BaseAddress extends Mixins(ValidationMixin, CountriesProvin
   @Prop({ default: false })
   readonly noPoBox: boolean
 
+  resetRegion() {
+    this.addressLocal['addressRegion'] = ''
+  }
+
   /** A local (working) copy of the address, to contain the fields edited by the component (ie, the model). */
   private addressLocal: object = {}
 
@@ -221,6 +226,7 @@ export default class BaseAddress extends Mixins(ValidationMixin, CountriesProvin
   private get addressCountry (): string {
     return this.addressLocal['addressCountry']
   }
+
 
   /** The Street Address Additional label with 'optional' as needed. */
   private get streetAddressAdditionalLabel (): string {


### PR DESCRIPTION
…rror in create_cfs_account_job

*Issue #:*
https://github.com/bcgov/entity/issues/15202

*Description of changes:*
Province is not set to empty after the country is changed to Canada / US. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
