### PR TITLE
Make npm-publish runnable

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -5,6 +5,7 @@ on:
     branches: master
     paths:
     - '**package.json'
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
Make it possible to run npm publish adhoc.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
