### PR TITLE
Added init file to python folder

### DIFF
--- a/python/src/sbc_common_components/__init__.py
+++ b/python/src/sbc_common_components/__init__.py
@@ -1,0 +1,14 @@
+# Copyright © 2019 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""This module holds general utility functions and helpers for the main package."""


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/<Put the github issue number here>

*Description of changes:*
poetry dependency resolution fails when sbc-common-components is added via 
_poetry add git+https://github.com/bcgov/sbc-common-components.git@master#subdirectory=python_
To fix this issue, init file is added in python/src/sbc-common-components folder

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
