### PR TITLE
Added an environment alert that displays what environment is passed in (DEV, TEST, or SANDBOX)

### DIFF
--- a/vue/sbc-common-components/src/components/SbcHeader.vue
+++ b/vue/sbc-common-components/src/components/SbcHeader.vue
@@ -1,20 +1,23 @@
 <template>
   <div class="d-flex">
     <header class="app-header" id="appHeader">
-      <v-container class="justify-space-between">
-        <a @click="goToHome()" class="brand">
-          <picture>
-            <source media="(min-width: 601px)"
-              srcset="../assets/img/gov_bc_logo_horiz.png">
-            <source media="(max-width: 600px)"
-              srcset="../assets/img/gov_bc_logo_vert.png">
-            <img class="brand__image"
-              src="../assets/img/gov_bc_logo_vert.png"
-              alt="Government of British Columbia Logo"
-              title="Government of British Columbia">
-          </picture>
-          <span class="brand__title">BC Registries <span class="brand__title--wrap">and Online Services</span></span>
-        </a>
+      <v-container class="justify-space-between"> 
+        <!-- Group for logo and alert -->
+        <div class="header-group d-flex align-center"> 
+          <!-- Brand/logo link -->
+          <a @click="goToHome()" class="brand d-flex align-center">
+            <picture>
+              <source media="(min-width: 601px)" srcset="../assets/img/gov_bc_logo_horiz.png">
+              <source media="(max-width: 600px)" srcset="../assets/img/gov_bc_logo_vert.png">
+              <img class="brand__image" src="../assets/img/gov_bc_logo_vert.png" alt="Government of British Columbia Logo" title="Government of British Columbia">
+            </picture>
+            <span class="brand__title">BC Registries <span class="brand__title--wrap">and Online Services</span></span>
+          </a>
+          <!-- Environment Alert -->
+          <v-alert v-if="environment" :color="alertColor" dense class="env-distinction"> 
+            {{environment}} Environment
+          </v-alert>
+        </div>
         <div v-if="showActions" class="app-header__actions">
 
           <!-- Product Selector -->
@@ -439,6 +442,7 @@ export default class SbcHeader extends Mixins(NavigationMixin) {
   @Prop({ default: true }) showActions!: boolean;
   @Prop({ default: true }) showLoginMenu!: boolean;
   @Prop({ default: '' }) dashboardReturnUrl !: string;
+  @Prop({ default: '' }) environment!: string;
 
   private readonly loginOptions = [
     {
@@ -457,6 +461,20 @@ export default class SbcHeader extends Mixins(NavigationMixin) {
       icon: 'mdi-account-group-outline'
     }
   ]
+
+  @Watch
+  get alertColor(): string {
+    switch (this.environment) {
+      case 'DEV':
+        return 'success';
+      case 'TEST':
+        return 'error';
+      case 'SANDBOX':
+        return 'warning';
+      default:
+        return '';
+    }
+  }
 
   // only for internal staff who belongs to bcreg
   get isStaff (): boolean {
@@ -667,6 +685,12 @@ $app-header-font-color: #ffffff;
     padding-top: 0;
     padding-bottom: 0;
   }
+}
+
+.env-distinction {
+  padding: 0px 10px; 
+  font-size: 0.875rem; 
+  margin: 0;
 }
 
 .brand {

--- a/vue/sbc-common-components/src/components/SbcHeader.vue
+++ b/vue/sbc-common-components/src/components/SbcHeader.vue
@@ -472,6 +472,7 @@ export default class SbcHeader extends Mixins(NavigationMixin) {
       case 'SANDBOX':
         return 'warning';
       default:
+        this.environment = ''
         return '';
     }
   }


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/<Put the github issue number here>

*Description of changes:*
Added an environment parameter that can be passed either 'DEV', 'TEST', or 'SANDBOX'. If one of these are passed in a banner is displayed showing the environment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
