### PR TITLE
Bumped up version numbers in package.json and package-lock.json for the updated Header component. 

### DIFF
--- a/vue/sbc-common-components/package-lock.json
+++ b/vue/sbc-common-components/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sbc-common-components",
-  "version": "3.0.12",
+  "version": "3.0.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/vue/sbc-common-components/package.json
+++ b/vue/sbc-common-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sbc-common-components",
-  "version": "3.0.12",
+  "version": "3.0.13",
   "private": false,
   "description": "Common Vue Components to be used across BC Registries and Online Services.",
   "license": "Apache-2.0",

--- a/vue/sbc-common-components/src/components/SbcHeader.vue
+++ b/vue/sbc-common-components/src/components/SbcHeader.vue
@@ -464,8 +464,9 @@ export default class SbcHeader extends Mixins(NavigationMixin) {
 
   @Watch
   get alertColor(): string {
-    switch (this.environment) {
+    switch (this.environment.toUpperCase()) {
       case 'DEV':
+      case 'DEVELOPMENT':
         return 'success';
       case 'TEST':
         return 'error';


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/<Put the github issue number here>

*Description of changes:*
 - Bumped up version numbers
 - Made it so case does not matter when passing in environment variables. Also made it so both 'dev' and 'development' can be passed in as an environment variable. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
