### PR TITLE
updated keyclock version

### DIFF
--- a/vue/sbc-common-components/package-lock.json
+++ b/vue/sbc-common-components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sbc-common-components",
-  "version": "4.0.9",
+  "version": "4.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sbc-common-components",
-      "version": "4.0.9",
+      "version": "4.0.10",
       "license": "Apache-2.0",
       "dependencies": {
         "@mdi/font": "^4.5.95",
@@ -14,7 +14,7 @@
         "axios": "^1.6.2",
         "clickout-event": "^1.1.2",
         "country-list": "^2.2.0",
-        "keycloak-js": "^9.0.3",
+        "keycloak-js": "^26.0.6",
         "launchdarkly-js-client-sdk": "^2.16.1",
         "lodash.uniqueid": "^4.0.1",
         "moment": "^2.29.4",
@@ -14262,11 +14262,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/js-sha256": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
-      "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA=="
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -14445,13 +14440,9 @@
       }
     },
     "node_modules/keycloak-js": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/keycloak-js/-/keycloak-js-9.0.3.tgz",
-      "integrity": "sha512-c8FFPa8YiJmPbJEMZ/mIrHflBR6FIFUm5xTWtIDzlrnoeF4u0wDmTBfo1u71rWIL1HanLvg3T+9AgR1NqfmGbA==",
-      "dependencies": {
-        "base64-js": "1.3.1",
-        "js-sha256": "0.9.0"
-      }
+      "version": "26.0.6",
+      "resolved": "https://registry.npmjs.org/keycloak-js/-/keycloak-js-26.0.6.tgz",
+      "integrity": "sha512-HHRuMOm5w4vAkhWyqs7VPQqYUCSyPagTdQcUIi7xF6XU9GoSZgh2jRtry5P4t6XxhyuMiCwWg7JN8W9cDyqRfQ=="
     },
     "node_modules/keyv": {
       "version": "3.1.0",

--- a/vue/sbc-common-components/package.json
+++ b/vue/sbc-common-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sbc-common-components",
-  "version": "4.0.9",
+  "version": "4.0.10",
   "private": false,
   "description": "Common Vue Components to be used across BC Registries and Online Services.",
   "license": "Apache-2.0",
@@ -25,7 +25,7 @@
     "axios": "^1.6.2",
     "clickout-event": "^1.1.2",
     "country-list": "^2.2.0",
-    "keycloak-js": "^9.0.3",
+    "keycloak-js": "^26.0.6",
     "launchdarkly-js-client-sdk": "^2.16.1",
     "lodash.uniqueid": "^4.0.1",
     "moment": "^2.29.4",

--- a/vue/sbc-common-components/src/services/keycloak.services.ts
+++ b/vue/sbc-common-components/src/services/keycloak.services.ts
@@ -171,7 +171,7 @@ class KeyCloakService {
     }
 
     return new Promise((resolve, reject) => {
-      this.kc = Keycloak(ConfigHelper.getKeycloakConfigUrl())
+      this.kc = new Keycloak(ConfigHelper.getKeycloakConfigUrl())
       ConfigHelper.addToSession(SessionStorageKeys.SessionSynced, false)
       this.kc.init(kcOptions)
         .then(authenticated => {


### PR DESCRIPTION

*Description of changes:*
Upgraded keycloak version from 9.0.3 to 26.0.6

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
