### PR TITLE
Fix SbcHeader Pinia store reactivity

### DIFF
--- a/vue/sbc-common-components/package-lock.json
+++ b/vue/sbc-common-components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sbc-common-components",
-  "version": "3.1.8",
+  "version": "3.1.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "sbc-common-components",
-      "version": "3.1.8",
+      "version": "3.1.9",
       "license": "Apache-2.0",
       "dependencies": {
         "@mdi/font": "^4.5.95",

--- a/vue/sbc-common-components/package.json
+++ b/vue/sbc-common-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sbc-common-components",
-  "version": "3.1.8",
+  "version": "3.1.9",
   "private": false,
   "description": "Common Vue 2 Components to be used across BC Registries and Online Services.",
   "license": "Apache-2.0",

--- a/vue/sbc-common-components/src/components/NavigationBar.vue
+++ b/vue/sbc-common-components/src/components/NavigationBar.vue
@@ -60,23 +60,16 @@ import { Component, Prop, Vue, Mixins } from 'vue-property-decorator'
 import { NavigationBarConfig, NavigationMenuItem } from '../models/NavigationBarConfig'
 import { useAccountStore } from '../stores/account'
 import { useAuthStore } from '../stores/auth'
-import { mapState, mapGetters } from 'pinia'
-
 @Component({
-  name: 'NavigationBar',
-  beforeCreate () {
-  this.$options.computed = {
-  ...(this.$options.computed || {}),
-  ...mapState(useAuthStore, ['token']),
-  ...mapState(useAccountStore, ['currentAccount']),
-  ...mapGetters(useAuthStore, ['isAuthenticated'])
-  }
-  }
+  name: 'NavigationBar'
   })
 export default class NavigationBar extends Vue {
   @Prop() configuration!: NavigationBarConfig
   @Prop({ default: false }) hide!: boolean
   private mobileNavDrawer = false
+
+  get isAuthenticated (): boolean { return useAuthStore().isAuthenticated }
+  get currentAccount () { return useAccountStore().currentAccount }
 
   private get showNavBar (): boolean {
     return !this.hide && this.configuration && this.configuration.menuItems.length > 0

--- a/vue/sbc-common-components/src/components/NotificationPanel.vue
+++ b/vue/sbc-common-components/src/components/NotificationPanel.vue
@@ -56,24 +56,14 @@
 import { Component, Emit, Prop, Vue } from 'vue-property-decorator'
 import { Notification } from '../models/notification'
 import { useNotificationStore } from '../stores/notification'
-import { mapState, mapActions } from 'pinia'
 import 'clickout-event'
 
 @Component({
-  name: 'NotificationPanel',
-  beforeCreate () {
-  this.$options.computed = {
-  ...(this.$options.computed || {}),
-  ...mapState(useNotificationStore, ['notifications'])
-  }
-  this.$options.methods = {
-  ...(this.$options.methods || {}),
-  ...mapActions(useNotificationStore, ['markAsRead'])
-  }
-  }
+  name: 'NotificationPanel'
   })
 export default class NotificationPanel extends Vue {
-  private readonly notifications!: Notification[]
+  get notifications (): Notification[] { return useNotificationStore().notifications }
+  markAsRead (): Promise<void> { return useNotificationStore().markAsRead() }
 
   /** Prop to display the dialog. */
   @Prop() showNotifications: boolean

--- a/vue/sbc-common-components/src/components/PaySystemAlert.vue
+++ b/vue/sbc-common-components/src/components/PaySystemAlert.vue
@@ -11,28 +11,17 @@
 import { Component, Vue } from 'vue-property-decorator'
 import SbcSystemBanner from './SbcSystemBanner.vue'
 import { useStatusStore } from '../stores/status'
-import { mapState, mapActions } from 'pinia'
 import { ServiceStatus } from '../models/ServiceStatus'
 
 @Component({
   components: {
   SbcSystemBanner
-  },
-  beforeCreate () {
-  this.$options.computed = {
-  ...(this.$options.computed || {}),
-  ...mapState(useStatusStore, ['paySystemStatus'])
-  }
-  this.$options.methods = {
-  ...(this.$options.methods || {}),
-  ...mapActions(useStatusStore, ['fetchPaySystemStatus'])
-  }
   }
   })
 export default class PaySystemAlert extends Vue {
   private statusAPIResponse : ServiceStatus | null = null
-  private readonly paySystemStatus!: ServiceStatus
-  private readonly fetchPaySystemStatus!: () => Promise<ServiceStatus>
+  get paySystemStatus (): ServiceStatus { return useStatusStore().paySystemStatus }
+  fetchPaySystemStatus (): Promise<ServiceStatus> { return useStatusStore().fetchPaySystemStatus() }
   private getBoolean (value: boolean | string | number): boolean {
     var resultVal = value
     if (typeof value === 'string') {

--- a/vue/sbc-common-components/src/components/SbcHeader.vue
+++ b/vue/sbc-common-components/src/components/SbcHeader.vue
@@ -345,7 +345,7 @@ import ConfigHelper from '../util/config-helper'
 import { useAccountStore } from '../stores/account'
 import { useAuthStore } from '../stores/auth'
 import { useNotificationStore } from '../stores/notification'
-import { mapState, mapActions, mapGetters, getActivePinia } from 'pinia'
+// pinia stores are used directly via useAuthStore(), useAccountStore(), useNotificationStore()
 import { UserSettings } from '../models/userSettings'
 import NavigationMixin from '../mixins/navigation-mixin'
 import { KCUserProfile } from '../models/KCUserProfile'
@@ -359,22 +359,6 @@ import { AccountStatus, LDFlags } from '../util/enums'
 import { appendAccountId, trimTrailingSlashURL } from '../util/common-util'
 
 @Component({
-  beforeCreate () {
-  this.$options.computed = {
-  ...(this.$options.computed || {}),
-  ...mapState(useAccountStore, ['currentAccount', 'pendingApprovalCount', 'currentUser']),
-  ...mapState(useNotificationStore, ['notificationCount', 'notificationUnreadPriorityCount', 'notificationUnreadCount']),
-  ...mapGetters(useAccountStore, ['accountName', 'switchableAccounts', 'username']),
-  ...mapGetters(useAuthStore, ['isAuthenticated', 'currentLoginSource'])
-  }
-  this.$options.methods = {
-  ...(this.$options.methods || {}),
-  ...mapActions(useAccountStore, ['loadUserInfo', 'syncAccount', 'syncCurrentAccount', 'syncUserProfile']),
-  ...mapActions(useAuthStore, ['syncWithSessionStorage']),
-  ...mapActions(useNotificationStore, ['markAsRead', 'fetchNotificationCount', 'fetchNotificationUnreadPriorityCount',
-    'fetchNotificationUnreadCount', 'syncNotifications'])
-  }
-  },
   components: {
   SbcProductSelector,
   BrowserVersionAlert,
@@ -384,28 +368,32 @@ import { appendAccountId, trimTrailingSlashURL } from '../util/common-util'
   })
 export default class SbcHeader extends Mixins(NavigationMixin) {
   private ldClient!: LDClient
-  private readonly currentAccount!: UserSettings | null
-  private readonly pendingApprovalCount!: number
-  private readonly username!: string
-  private readonly accountName!: string
-  private readonly currentLoginSource!: string
-  private readonly isAuthenticated!: boolean
-  private readonly switchableAccounts!: UserSettings[]
-  private readonly loadUserInfo!: () => KCUserProfile
-  private readonly syncAccount!: () => Promise<void>
-  private readonly syncCurrentAccount!: (userSettings: UserSettings) => Promise<UserSettings>
-  private readonly syncUserProfile!: () => Promise<void>
-  private readonly syncWithSessionStorage!: () => void
-  private readonly currentUser!: any
   private notificationPanel = false
-  private readonly notificationUnreadPriorityCount!: number
-  private readonly notificationUnreadCount!: number
-  private readonly fetchNotificationUnreadPriorityCount!: () => Promise<void>
-  private readonly fetchNotificationUnreadCount!: () => Promise<void>
-  private readonly markAsRead!: () => Promise<void>
-  private readonly notificationCount!: number
-  private readonly fetchNotificationCount!: () => Promise<void>
-  private readonly syncNotifications!: () => Promise<void>
+
+  get currentAccount (): UserSettings | null { return useAccountStore().currentAccount }
+  get pendingApprovalCount (): number { return useAccountStore().pendingApprovalCount }
+  get currentUser (): any { return useAccountStore().currentUser }
+  get accountName (): string { return useAccountStore().accountName }
+  get switchableAccounts (): UserSettings[] { return useAccountStore().switchableAccounts }
+  get username (): string { return useAccountStore().username }
+
+  get isAuthenticated (): boolean { return useAuthStore().isAuthenticated }
+  get currentLoginSource (): string { return useAuthStore().currentLoginSource }
+
+  get notificationCount (): number { return useNotificationStore().notificationCount }
+  get notificationUnreadPriorityCount (): number { return useNotificationStore().notificationUnreadPriorityCount }
+  get notificationUnreadCount (): number { return useNotificationStore().notificationUnreadCount }
+
+  loadUserInfo (): KCUserProfile { return useAccountStore().loadUserInfo() }
+  syncAccount (): Promise<void> { return useAccountStore().syncAccount() }
+  syncCurrentAccount (settings: UserSettings): Promise<UserSettings> { return useAccountStore().syncCurrentAccount(settings) }
+  syncUserProfile (): Promise<void> { return useAccountStore().syncUserProfile() }
+
+  markAsRead (): Promise<void> { return useNotificationStore().markAsRead() }
+  fetchNotificationCount (): Promise<void> { return useNotificationStore().fetchNotificationCount() }
+  fetchNotificationUnreadPriorityCount (): Promise<void> { return useNotificationStore().fetchNotificationUnreadPriorityCount() }
+  fetchNotificationUnreadCount (): Promise<void> { return useNotificationStore().fetchNotificationUnreadCount() }
+  syncNotifications (): Promise<void> { return useNotificationStore().syncNotifications() }
 
   @Prop({ default: '' }) redirectOnLoginSuccess!: string;
   @Prop({ default: '' }) redirectOnLoginFail!: string;
@@ -479,9 +467,7 @@ export default class SbcHeader extends Mixins(NavigationMixin) {
   }
 
   private async mounted () {
-    if (getActivePinia()) {
-      this.syncWithSessionStorage()
-    }
+    useAuthStore().syncWithSessionStorage()
     if (this.isAuthenticated) {
       await this.loadUserInfo()
       await this.syncAccount()

--- a/vue/sbc-common-components/src/components/SbcHeader.vue
+++ b/vue/sbc-common-components/src/components/SbcHeader.vue
@@ -345,7 +345,7 @@ import ConfigHelper from '../util/config-helper'
 import { useAccountStore } from '../stores/account'
 import { useAuthStore } from '../stores/auth'
 import { useNotificationStore } from '../stores/notification'
-// pinia stores are used directly via useAuthStore(), useAccountStore(), useNotificationStore()
+// pinia stores are accessed directly
 import { UserSettings } from '../models/userSettings'
 import NavigationMixin from '../mixins/navigation-mixin'
 import { KCUserProfile } from '../models/KCUserProfile'

--- a/vue/sbc-common-components/src/components/SbcProductSelector.vue
+++ b/vue/sbc-common-components/src/components/SbcProductSelector.vue
@@ -112,25 +112,14 @@ import { Component, Vue } from 'vue-property-decorator'
 import ConfigHelper from '../util/config-helper'
 import { Product, Products } from '../models/product'
 import { useProductsStore } from '../stores/product'
-import { mapState, mapActions } from 'pinia'
-
 @Component({
-  name: 'SbcProductSelector',
-  beforeCreate () {
-  this.$options.computed = {
-  ...(this.$options.computed || {}),
-  ...mapState(useProductsStore, ['products', 'partners'])
-  }
-  this.$options.methods = {
-  ...(this.$options.methods || {}),
-  ...mapActions(useProductsStore, ['syncProducts'])
-  }
-  }
+  name: 'SbcProductSelector'
   })
 export default class SbcProductSelector extends Vue {
   private dialog = false
-  private readonly products!: Products
-  private readonly syncProducts!: () => Promise<void>
+  get products (): Products { return useProductsStore().products }
+  get partners () { return useProductsStore().partners }
+  syncProducts (): Promise<void> { return useProductsStore().syncProducts() }
 
   private async mounted () {
     await this.syncProducts()


### PR DESCRIPTION
Replace `beforeCreate` hook using `mapState`/`mapGetters`/`mapActions` with direct store access via computed getters and method wrappers
The `beforeCreate` pattern lost reactivity in Vue 2.7 + Pinia + Vite environments